### PR TITLE
fix: replace unstable toDataURL with stable toBlob

### DIFF
--- a/src/app/(tools)/rounded-border/rounded-tool.tsx
+++ b/src/app/(tools)/rounded-border/rounded-tool.tsx
@@ -3,6 +3,7 @@ import { usePlausible } from "next-plausible";
 import { useMemo, useState } from "react";
 import { ChangeEvent } from "react";
 import React from "react";
+import createBlob from "@/app/utils/create-blob";
 
 type Radius = 2 | 4 | 8 | 16 | 32 | 64;
 
@@ -23,15 +24,21 @@ function useImageConverter(props: {
     };
   }, [props.imageContent, props.imageMetadata]);
 
+  const blobUrlRef = React.useRef<string | null>(null);
+
   const convertToPng = async () => {
     const ctx = props.canvas?.getContext("2d");
     if (!ctx) throw new Error("Failed to get canvas context");
 
-    const saveImage = () => {
+    const saveImage = async () => {
       if (props.canvas) {
-        const dataURL = props.canvas.toDataURL("image/png");
+        const blob = await createBlob(props.canvas);
+        if (blobUrlRef.current !== null) {
+          URL.revokeObjectURL(blobUrlRef.current);
+        }
+        blobUrlRef.current = URL.createObjectURL(blob);
         const link = document.createElement("a");
-        link.href = dataURL;
+        link.href = blobUrlRef.current;
         const imageFileName = props.imageMetadata.name ?? "image_converted";
         link.download = `${imageFileName.replace(/\..+$/, "")}.png`;
         link.click();

--- a/src/app/(tools)/svg-to-png/svg-tool.tsx
+++ b/src/app/(tools)/svg-to-png/svg-tool.tsx
@@ -39,16 +39,22 @@ function useSvgConverter(props: {
     };
   }, [props.svgContent, props.scale, props.imageMetadata]);
 
+  const blobUrlRef = React.useRef<string | null>(null);
+
   const convertToPng = async () => {
     const ctx = props.canvas?.getContext("2d");
     if (!ctx) throw new Error("Failed to get canvas context");
 
     // Trigger a "save image" of the resulting canvas content
-    const saveImage = () => {
+    const saveImage = async () => {
       if (props.canvas) {
-        const dataURL = props.canvas.toDataURL("image/png");
+        const blob = await createBlob(props.canvas);
+        if (blobUrlRef.current !== null) {
+          URL.revokeObjectURL(blobUrlRef.current);
+        }
+        blobUrlRef.current = URL.createObjectURL(blob);
         const link = document.createElement("a");
-        link.href = dataURL;
+        link.href = blobUrlRef.current;
         const svgFileName = props.imageMetadata.name ?? "svg_converted";
 
         // Remove the .svg extension
@@ -112,6 +118,7 @@ export const useFileUploader = () => {
 };
 
 import React from "react";
+import createBlob from "@/app/utils/create-blob";
 
 interface SVGRendererProps {
   svgContent: string;

--- a/src/app/utils/create-blob.ts
+++ b/src/app/utils/create-blob.ts
@@ -1,0 +1,10 @@
+export default async function createBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob === null) {
+        return reject("Failed to create blob from canvas");
+      }
+      resolve(blob);
+    });
+  });
+}


### PR DESCRIPTION
Fix an issue with [toDataURL](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL), causing and overflow in the browser URL length limit. 

Note, this fix needs applying to the [SquareTool](https://github.com/t3dotgg/quickpic/blob/main/src/app/(tools)/square-image/square-tool.tsx) component, but was a more involved fix to apply, so I'll leave that to someone else.