### PR TITLE
Add parsing for other absolute dimensions

### DIFF
--- a/src/app/(tools)/svg-to-png/svg-tool.tsx
+++ b/src/app/(tools)/svg-to-png/svg-tool.tsx
@@ -6,12 +6,56 @@ import { ChangeEvent } from "react";
 
 type Scale = 1 | 2 | 4 | 8 | 16 | 32 | 64;
 
+function parseSVGDimension(dim: string | null, defaultValue = 300) {
+  if (!dim) return defaultValue;
+
+  // regex to extract the numeric value and unit
+  const regex = /^([\d.]+)([a-z%]*)$/i;
+  const match = dim.trim().match(regex);
+
+  if (!match) {
+    console.warn(`Unable to parse dimension "${dim}". Using default value ${defaultValue}px.`);
+    return defaultValue;
+  }
+
+  const value = parseFloat(match[1]);
+  const unit = match[2].toLowerCase();
+
+  return Math.floor((() => {
+    switch (unit) {
+      case '':
+      case 'px':
+        return value;
+      case 'cm':
+        return value * 96 / 2.54; // 96 DPI assumed
+      case 'mm':
+        return value * 96 / 25.4;
+      case 'Q':
+        return value * 96 / 2.54 / 40;
+      case 'in':
+        return value * 96;
+      case 'pt':
+        return value * 96 / 72;
+      case 'pc':
+        return value * 96 / 6;
+      case 'em':
+      case 'rem':
+        // assuming 16px per em/rem
+        return value * 16;
+      default:
+        console.warn(`Unsupported unit "${unit}". Using default value ${defaultValue}px.`);
+        return defaultValue;
+    }
+  })());
+}
+
 function scaleSvg(svgContent: string, scale: Scale) {
   const parser = new DOMParser();
   const svgDoc = parser.parseFromString(svgContent, "image/svg+xml");
   const svgElement = svgDoc.documentElement;
-  const width = parseInt(svgElement.getAttribute("width") || "300");
-  const height = parseInt(svgElement.getAttribute("height") || "150");
+
+  const width = parseSVGDimension(svgElement.getAttribute("width"), 300);
+  const height = parseSVGDimension(svgElement.getAttribute("height"), 150);
 
   const scaledWidth = width * scale;
   const scaledHeight = height * scale;
@@ -93,8 +137,8 @@ export const useFileUploader = () => {
         const parser = new DOMParser();
         const svgDoc = parser.parseFromString(content, "image/svg+xml");
         const svgElement = svgDoc.documentElement;
-        const width = parseInt(svgElement.getAttribute("width") || "300");
-        const height = parseInt(svgElement.getAttribute("height") || "150");
+        const width = parseSVGDimension(svgElement.getAttribute("width"), 300);
+        const height = parseSVGDimension(svgElement.getAttribute("height"), 150);
 
         setSvgContent(content);
         setImageMetadata({ width, height, name: file.name });


### PR DESCRIPTION
Parse the unit of the SVG's width/height alongside its value to avoid incorrect unit conversions (ex. 12x9.9 in -> 12x9 px)