### PR TITLE
Add flexible SVG scaling options -- with video overview/demo

### DIFF
--- a/src/app/(tools)/svg-to-png/svg-tool.tsx
+++ b/src/app/(tools)/svg-to-png/svg-tool.tsx
@@ -265,6 +265,7 @@ export function SVGTool() {
         {/* Custom Scale */}
         <input
           type="number"
+          defaultValue={scale.type === "custom" ? scale.value : ""}
           min="1"
           step="0.1"
           className={`w-20 px-3 py-1 rounded-md text-sm font-medium transition-colors ${
@@ -293,6 +294,7 @@ export function SVGTool() {
           <div className="flex gap-2">
             <input
               type="number"
+              defaultValue={scale.x}
               min="1"
               step="0.1"
               className="w-20 px-3 py-1 rounded-md text-sm font-medium bg-blue-600 text-white"
@@ -311,6 +313,7 @@ export function SVGTool() {
             />
             <input
               type="number"
+              defaultValue={scale.y}
               min="1"
               step="0.1"
               className="w-20 px-3 py-1 rounded-md text-sm font-medium bg-blue-600 text-white"


### PR DESCRIPTION
Hello!

My PR adds the ability to scale an svg both on the x/y axes at the same time, and independently. So you could scale an image either 50x, or set a custom x and y value for the PNG. Additionally I learned that in Chrome, the max pixels on a canvas is 268,435,456 [source](https://stackoverflow.com/a/11585939), so I added a quick warning if you exceed that, this can be easily removed if wanted though.

I created a quick video going over and demonstrating the changes, and the quick code changes I made. 

Thanks!

https://github.com/user-attachments/assets/5fbe47d9-8970-4878-9c86-ceb40a618684
