### PR TITLE
Show a preview of the converted png

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   },
+  "packageManager": "pnpm@9.12.3",
   "pnpm": {
     "overrides": {
       "@types/react": "npm:types-react@19.0.0-rc.1",


### PR DESCRIPTION
By proactively converting the svg to png, we can show a preview of the png before the user downloads it. This is helpful when using an svg that has a very low base resolution, as otherwise would need to download to see if its high enough.