### PR TITLE
Centred Text on smaller window 

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ export default function Home() {
   return (
     <div className="flex min-h-screen flex-col justify-between p-8 font-[family-name:var(--font-geist-sans)] sm:p-20">
       <main className="flex flex-grow flex-col items-center justify-center">
-        <div>
+        <div className="text-center">
           Hi. I&apos;m{" "}
           <a
             href="https://twitter.com/t3dotgg"


### PR DESCRIPTION
Centred text on the home screen cause I couldn't unsee it.
## Check list
- [x] Provide a video or screenshots of any visual changes made
- [x] Run `pnpm run check` and make sure everything works
<img width="456" alt="Screenshot 2024-11-11 at 4 11 22 PM" src="https://github.com/user-attachments/assets/ff3ea87a-7127-46d7-9933-3e0d6a8fb119">
<img width="384" alt="Screenshot 2024-11-11 at 4 23 25 PM" src="https://github.com/user-attachments/assets/892e8523-512a-4bbb-a261-6b491a4279e6">
