### PR TITLE
Added a "Pick Your Shape" selector to switch between rounded edges and a perfect circle.

### DIFF
--- a/src/components/border-radius-selector.tsx
+++ b/src/components/border-radius-selector.tsx
@@ -7,6 +7,7 @@ interface BorderRadiusSelectorProps {
   onChange: (value: number | "custom") => void;
   customValue?: number;
   onCustomValueChange?: (value: number) => void;
+  disabled?: boolean; // Added the optional 'disabled' prop
 }
 
 export function BorderRadiusSelector({
@@ -16,6 +17,7 @@ export function BorderRadiusSelector({
   onChange,
   customValue,
   onCustomValueChange,
+  disabled, // Destructure the 'disabled' prop
 }: BorderRadiusSelectorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const selectedRef = useRef<HTMLButtonElement>(null);
@@ -24,11 +26,11 @@ export function BorderRadiusSelector({
   useEffect(() => {
     if (selectedRef.current && highlightRef.current && containerRef.current) {
       const container = containerRef.current;
-      const selected = selectedRef.current;
+      const selectedButton = selectedRef.current;
       const highlight = highlightRef.current;
 
       const containerRect = container.getBoundingClientRect();
-      const selectedRect = selected.getBoundingClientRect();
+      const selectedRect = selectedButton.getBoundingClientRect();
 
       highlight.style.left = `${selectedRect.left - containerRect.left}px`;
       highlight.style.width = `${selectedRect.width}px`;
@@ -79,17 +81,18 @@ export function BorderRadiusSelector({
               onClick={() =>
                 onChange(typeof option === "number" ? option : "custom")
               }
+              disabled={disabled}
               className={`relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
                 option === selected
                   ? "text-white"
                   : "text-white/80 hover:text-white"
-              }`}
+              } ${disabled ? "cursor-not-allowed opacity-50" : ""}`}
             >
-              {option === "custom" ? "Custom" : option}
+              {option === "custom" ? "Custom" : `${option}px`}
             </button>
           ))}
         </div>
-        {selected === "custom" && (
+        {selected === "custom" && !disabled && (
           <div className="flex items-center gap-2">
             <div className="relative flex items-center">
               <input


### PR DESCRIPTION
A new feature to the RoundedTool that allows users to make images perfectly circular, regardless of their original aspect ratio. This is implemented via a new "Make image a circle" checkbox toggle.

![wide-img-circle-disabled](https://github.com/user-attachments/assets/0bbcbe05-e711-4c15-aea7-dbe794624962)
![wide-img-circle-enabled](https://github.com/user-attachments/assets/302e4ed6-1517-4f80-b4d8-1548692fa12a)

It’d be awesome to add X/Y controls to choose the crop spot, but that’s a bit out of my league. Also had to also update the `border-radius-selector.tsx` component to make it work.

![pnpm run check ](https://github.com/user-attachments/assets/9c5010dc-1848-44a0-b6d2-9907233621dc)

