### PR TITLE
Update the description text for svg-tool to be more concise

### DIFF
--- a/src/app/(tools)/svg-to-png/page.tsx
+++ b/src/app/(tools)/svg-to-png/page.tsx
@@ -2,7 +2,7 @@ import { SVGTool } from "./svg-tool";
 
 export const metadata = {
   title: "SVG to PNG converter - QuickPic",
-  description: "Convert SVGs to PNGs. Also makes them bigger.",
+  description: "Make SVGs into PNGs for free. (You can scale size too.)",
 };
 
 export default function SVGToolPage() {

--- a/src/app/(tools)/svg-to-png/svg-tool.tsx
+++ b/src/app/(tools)/svg-to-png/svg-tool.tsx
@@ -153,7 +153,7 @@ function SVGToolCore(props: { fileUploaderProps: FileUploaderResult }) {
   if (!imageMetadata)
     return (
       <UploadBox
-        title="Make SVGs into PNGs. Also makes them bigger. (100% free btw.)"
+        title="Make SVGs into PNGs for free. (You can scale size too.)"
         description="Upload SVG"
         accept=".svg"
         onChange={handleFileUploadEvent}


### PR DESCRIPTION
I changes the description and text from this:
`Make SVGs into PNGs. Also makes them bigger. (100% free btw.)`
![image](https://github.com/user-attachments/assets/411115b9-34c9-4b20-9fa8-c261b56b3067)
To this:
`Make SVGs into PNGs for free. (You can scale size too.)`
![image](https://github.com/user-attachments/assets/e3ab3e15-79ea-4276-b6fa-5ac52eee05bd)
Having 3 sentences for 2 points seems like too much so I simplified that by making it clearer and more concise.

P.S. I also noticed that the metadata description did not match the text, I don't know if that was intentional or not but I changed it anyway.