### PR TITLE
Reupload button to save mere seconds when using square tool

### DIFF
--- a/src/app/(tools)/square-image/square-tool.tsx
+++ b/src/app/(tools)/square-image/square-tool.tsx
@@ -133,10 +133,7 @@ function SquareToolCore(props: { fileUploaderProps: FileUploaderResult }) {
         >
           Save Image
         </button>
-        <ReuploadBox
-          accept="image/*"
-          onChange={handleFileUploadEvent}
-        />
+        <ReuploadBox accept="image/*" onChange={handleFileUploadEvent} />
       </div>
     </div>
   );

--- a/src/app/(tools)/square-image/square-tool.tsx
+++ b/src/app/(tools)/square-image/square-tool.tsx
@@ -10,6 +10,7 @@ import {
   useFileUploader,
 } from "@/hooks/use-file-uploader";
 import { useEffect, useState } from "react";
+import ReuploadBox from "@/components/shared/reupload-box";
 
 function SquareToolCore(props: { fileUploaderProps: FileUploaderResult }) {
   const { imageContent, imageMetadata, handleFileUploadEvent, cancel } =
@@ -132,6 +133,10 @@ function SquareToolCore(props: { fileUploaderProps: FileUploaderResult }) {
         >
           Save Image
         </button>
+        <ReuploadBox
+          accept="image/*"
+          onChange={handleFileUploadEvent}
+        />
       </div>
     </div>
   );

--- a/src/components/shared/reupload-box.tsx
+++ b/src/components/shared/reupload-box.tsx
@@ -7,7 +7,7 @@ interface ReuploadBoxProps {
 
 export default function ReuploadBox({ accept, onChange }: ReuploadBoxProps) {
   return (
-    <label className="inline-flex cursor-pointer items-center gap-2 rounded-lg bg-blue-600 px-3 py-2 text-white shadow-sm transition-colors hover:bg-blue-700 focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2">
+    <label className="inline-flex cursor-pointer items-center gap-2 rounded-lg bg-blue-600 px-3 py-2 text-white shadow-sm transition-colors focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-blue-700">
       <span className="text-sm font-medium">Reupload</span>
       <input
         type="file"

--- a/src/components/shared/reupload-box.tsx
+++ b/src/components/shared/reupload-box.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+interface ReuploadBoxProps {
+  accept: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default function ReuploadBox({ accept, onChange }: ReuploadBoxProps) {
+  return (
+    <label className="inline-flex cursor-pointer items-center gap-2 rounded-lg bg-blue-600 px-3 py-2 text-white shadow-sm transition-colors hover:bg-blue-700 focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2">
+      <span className="text-sm font-medium">Reupload</span>
+      <input
+        type="file"
+        onChange={onChange}
+        accept={accept}
+        className="hidden"
+      />
+    </label>
+  );
+}


### PR DESCRIPTION
Please make sure you do the following before filing your PR:
- [x] Provide a video or screenshots of any visual changes made
- [x] Run `pnpm run check` and make sure everything passes

1.
<img width="1054" alt="1" src="https://github.com/user-attachments/assets/5d163fd0-8b17-499f-b8a2-d04672abdeaf">

2.
<img width="1042" alt="2" src="https://github.com/user-attachments/assets/481616a7-154d-41d6-a354-b08388921bfc">

3.
<img width="1040" alt="3" src="https://github.com/user-attachments/assets/b75da388-afdf-4433-93a7-0bad445b59ad">

4.
<img width="1053" alt="4" src="https://github.com/user-attachments/assets/78b01a98-f221-40ac-afd9-ab5002e449c4">


Strange images found from /r/memes FYI. 

Could probably apply to other parts of the site but felt like I'd throw it out there first and see what people think. I found having to go back to restart the image conversion process a little tedious and so this way I can either CMD+V a new picture in or simply hit 'reupload' to start the user journey again.