### PR TITLE
bugfix - Corner Rounder - Text overlap with custom border radius input box

### DIFF
--- a/src/components/border-radius-selector.tsx
+++ b/src/components/border-radius-selector.tsx
@@ -99,7 +99,7 @@ export function BorderRadiusSelector({
                 value={customValue}
                 onChange={handleInputChange}
                 onKeyDown={handleKeyDown}
-                className="w-24 rounded-lg bg-white/5 px-3 py-1.5 text-sm text-white"
+                className="mr-5 w-24 rounded-lg bg-white/5 px-3 py-1.5 text-sm text-white"
                 placeholder="Enter radius"
               />
               <span className="absolute right-3 text-sm text-white/60">px</span>


### PR DESCRIPTION
Fixes #88 

Chrome:
<img width="424" alt="image" src="https://github.com/user-attachments/assets/0d31e6af-93dd-42a7-89ec-2c888e151854">

Firefox:
<img width="418" alt="image" src="https://github.com/user-attachments/assets/2c69a6e9-f1ae-47a5-9dd9-c1ba53087435">

Safari:
<img width="418" alt="image" src="https://github.com/user-attachments/assets/d1e4452c-67e1-4b6d-ac15-8482080b82ee">



Please make sure you do the following before filing your PR:
- [x] Provide a video or screenshots of any visual changes made
- [x] Run `pnpm run check` and make sure everything passes
