### PR TITLE
"Match" background option for Square tool

### DIFF
--- a/src/app/(tools)/square-image/square-tool.tsx
+++ b/src/app/(tools)/square-image/square-tool.tsx
@@ -16,7 +16,7 @@ function SquareToolCore(props: { fileUploaderProps: FileUploaderResult }) {
     props.fileUploaderProps;
 
   const [backgroundColor, setBackgroundColor] = useLocalStorage<
-    "black" | "white"
+    "black" | "white" | "match"
   >("squareTool_backgroundColor", "white");
 
   const [squareImageContent, setSquareImageContent] = useState<string | null>(
@@ -37,9 +37,29 @@ function SquareToolCore(props: { fileUploaderProps: FileUploaderResult }) {
       ctx.fillStyle = backgroundColor;
       ctx.fillRect(0, 0, size, size);
 
+      const tempCanvas = document.createElement("canvas");
+      tempCanvas.width = 1;
+      tempCanvas.height = 1;
+      const tempCtx = tempCanvas.getContext("2d");
+
       // Load and center the image
       const img = new Image();
       img.onload = () => {
+        // Handle Match background option
+        if (backgroundColor == "match") {
+          if (!tempCtx) return;
+          // Get top-left pixel color
+          tempCtx.drawImage(img, 0, 0, 1, 1, 0, 0, 1, 1);
+          const pixelData = tempCtx.getImageData(0, 0, 1, 1).data;
+          const imageBg = `rgb(${pixelData[0]}, ${pixelData[1]}, ${pixelData[2]})`;
+          console.log(imageBg);
+
+          // Refill background
+          ctx.fillStyle = imageBg;
+          ctx.fillRect(0, 0, size, size);
+        }
+
+        // Draw image
         const x = (size - imageMetadata.width) / 2;
         const y = (size - imageMetadata.height) / 2;
         ctx.drawImage(img, x, y);
@@ -108,7 +128,7 @@ function SquareToolCore(props: { fileUploaderProps: FileUploaderResult }) {
 
       <OptionSelector
         title="Background Color"
-        options={["white", "black"]}
+        options={["white", "black", "match"]}
         selected={backgroundColor}
         onChange={setBackgroundColor}
         formatOption={(option) =>

--- a/src/app/(tools)/square-image/square-tool.tsx
+++ b/src/app/(tools)/square-image/square-tool.tsx
@@ -52,7 +52,6 @@ function SquareToolCore(props: { fileUploaderProps: FileUploaderResult }) {
           tempCtx.drawImage(img, 0, 0, 1, 1, 0, 0, 1, 1);
           const pixelData = tempCtx.getImageData(0, 0, 1, 1).data;
           const imageBg = `rgb(${pixelData[0]}, ${pixelData[1]}, ${pixelData[2]})`;
-          console.log(imageBg);
 
           // Refill background
           ctx.fillStyle = imageBg;


### PR DESCRIPTION
Adds "Match" background color option to the Square tool, which will match the background of the image itself (top-left pixel color, to be specific 😊)

https://github.com/user-attachments/assets/a9e5bbf7-bb41-4bc1-9284-edbfbeac4afb

Please make sure you do the following before filing your PR:
- [x] Provide a video or screenshots of any visual changes made
- [x] Run `pnpm run check` and make sure everything passes
