### PR TITLE
feat: fetch file from url + more

### DIFF
--- a/src/app/(tools)/layout.tsx
+++ b/src/app/(tools)/layout.tsx
@@ -1,13 +1,14 @@
 import Link from "next/link";
 
-import { ArrowLeftIcon, GitHubIcon } from "@/components/shared/icons";
+import { Footer } from "@/components/shared/footer";
+import { ArrowLeftIcon } from "@/components/shared/icons";
 
 function BackButton() {
   return (
     <div className="fixed left-4 top-4 z-50">
       <Link
         href="/"
-        className="flex items-center gap-2 rounded-md px-3 py-1 text-sm font-medium text-gray-500 transition-colors duration-200 hover:text-gray-200"
+        className="flex items-center gap-1 px-3 py-1 text-sm font-medium text-gray-500 transition-colors duration-200 hover:text-gray-200"
       >
         <ArrowLeftIcon strokeWidth={2.5} />
         Back
@@ -27,17 +28,7 @@ export default function ToolsLayout({
       <main className="flex flex-col grow items-center justify-center">
         {children}
       </main>
-      <footer className="mt-8 text-center text-sm text-gray-500">
-        <a
-          href="https://github.com/t3dotgg/quickpic"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 font-medium hover:text-gray-200 focus:text-gray-200 transition-colors duration-200"
-        >
-          <GitHubIcon />
-          View on GitHub
-        </a>
-      </footer>
+      <Footer />
     </div>
   );
 }

--- a/src/app/(tools)/layout.tsx
+++ b/src/app/(tools)/layout.tsx
@@ -8,7 +8,7 @@ function BackButton() {
     <div className="fixed left-4 top-4 z-50">
       <Link
         href="/"
-        className="flex items-center gap-1 px-3 py-1 text-sm font-medium text-gray-500 transition-colors duration-200 hover:text-gray-200"
+        className="flex items-center gap-2 px-3 py-1 text-sm font-medium text-gray-500 transition-colors duration-200 hover:text-gray-200"
       >
         <ArrowLeftIcon strokeWidth={2.5} />
         Back

--- a/src/app/(tools)/layout.tsx
+++ b/src/app/(tools)/layout.tsx
@@ -25,7 +25,7 @@ export default function ToolsLayout({
   return (
     <div className="flex min-h-screen flex-col justify-between px-8 pb-4 font-[family-name:var(--font-geist-sans)]">
       <BackButton />
-      <main className="flex flex-col grow items-center justify-center">
+      <main className="flex grow flex-col items-center justify-center">
         {children}
       </main>
       <Footer />

--- a/src/app/(tools)/layout.tsx
+++ b/src/app/(tools)/layout.tsx
@@ -25,7 +25,7 @@ export default function ToolsLayout({
   return (
     <div className="flex min-h-screen flex-col justify-between px-8 pb-4 font-[family-name:var(--font-geist-sans)]">
       <BackButton />
-      <main className="flex grow flex-col items-center justify-center">
+      <main className="mt-[60px] flex grow flex-col items-center justify-center">
         {children}
       </main>
       <Footer />

--- a/src/app/(tools)/layout.tsx
+++ b/src/app/(tools)/layout.tsx
@@ -5,7 +5,7 @@ function BackButton() {
     <div className="fixed left-4 top-4 z-50">
       <Link
         href="/"
-        className="flex items-center gap-2 rounded-md px-3 py-1 text-sm font-medium text-gray-400 transition-colors duration-200 hover:text-gray-200"
+        className="flex items-center gap-2 rounded-md px-3 py-1 text-sm font-medium text-gray-500 transition-colors duration-200 hover:text-gray-200"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -33,9 +33,9 @@ export default function ToolsLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex min-h-screen flex-col justify-between p-8 font-[family-name:var(--font-geist-sans)] sm:p-20">
+    <div className="flex min-h-screen flex-col justify-between px-8 pb-4 font-[family-name:var(--font-geist-sans)]">
       <BackButton />
-      <main className="flex flex-grow flex-col items-center justify-center">
+      <main className="flex flex-col grow items-center justify-center">
         {children}
       </main>
       <footer className="mt-8 text-center text-sm text-gray-500">

--- a/src/app/(tools)/layout.tsx
+++ b/src/app/(tools)/layout.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { ArrowLeftIcon, GitHubIcon } from "@/components/shared/icons";
+
 function BackButton() {
   return (
     <div className="fixed left-4 top-4 z-50">
@@ -7,20 +9,7 @@ function BackButton() {
         href="/"
         className="flex items-center gap-2 rounded-md px-3 py-1 text-sm font-medium text-gray-500 transition-colors duration-200 hover:text-gray-200"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          className="h-4 w-4"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M10 19l-7-7m0 0l7-7m-7 7h18"
-          />
-        </svg>
+        <ArrowLeftIcon strokeWidth={2.5} />
         Back
       </Link>
     </div>
@@ -43,8 +32,9 @@ export default function ToolsLayout({
           href="https://github.com/t3dotgg/quickpic"
           target="_blank"
           rel="noopener noreferrer"
-          className="hover:underline"
+          className="inline-flex items-center gap-1 font-medium hover:text-gray-200 focus:text-gray-200 transition-colors duration-200"
         >
+          <GitHubIcon />
           View on GitHub
         </a>
       </footer>

--- a/src/app/(tools)/rounded-border/page.tsx
+++ b/src/app/(tools)/rounded-border/page.tsx
@@ -6,5 +6,5 @@ export const metadata = {
 };
 
 export default function RoundedToolPage() {
-  return <RoundedTool />;
+  return <RoundedTool title={metadata.title} />;
 }

--- a/src/app/(tools)/rounded-border/rounded-tool.tsx
+++ b/src/app/(tools)/rounded-border/rounded-tool.tsx
@@ -8,6 +8,7 @@ import { BorderRadiusSelector } from "@/components/border-radius-selector";
 import { ErrorMessage } from "@/components/shared/error-message";
 import { FetchFromUrlForm } from "@/components/shared/fetch-from-url-form";
 import { FileDropzone } from "@/components/shared/file-dropzone";
+import { ClipboardPasteIcon, DownloadIcon } from "@/components/shared/icons";
 import { OptionSelector } from "@/components/shared/option-selector";
 import { PreviewScale } from "@/components/shared/preview-scale";
 import { UploadBox } from "@/components/shared/upload-box";
@@ -177,22 +178,13 @@ function SaveAsPngButton({
           plausible("convert-image-to-png");
           void convertToPng();
         }}
-        className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
+        className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
       >
+        <DownloadIcon strokeWidth={2.5} />
         Save as PNG
       </button>
     </div>
   );
-}
-
-function ClipboardPasteIcon() {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-4 -ml-1 shrink-0">
-      <path d="M15 2H9a1 1 0 0 0-1 1v2c0 .6.4 1 1 1h6c.6 0 1-.4 1-1V3c0-.6-.4-1-1-1Z"/>
-      <path d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2M16 4h2a2 2 0 0 1 2 2v2M11 14h10"/>
-      <path d="m17 10 4 4-4 4"/>
-    </svg>
-  )
 }
 
 type RoundedToolCoreProps = {
@@ -220,6 +212,8 @@ function RoundedToolCore({
   const [imageMetadata, setImageMetadata] = useState<ImageMetadata>(fileUploaderProps.imageMetadata);
   const [imageContent, setImageContent] = useState<string>(fileUploaderProps.imageContent);
   const [previewScale, setPreviewScale] = useState<number | null>(null);
+
+  const SubtitleIcon = <ClipboardPasteIcon className="-ml-1" />;
   
   const cancel = () => {
     fileUploaderProps.cancel();
@@ -292,7 +286,7 @@ function RoundedToolCore({
         <UploadBox
           title="Add rounded borders to your images. Quick and easy."
           subtitle="Allows pasting images from clipboard"
-          subtitleIcon={ClipboardPasteIcon}
+          subtitleIcon={SubtitleIcon}
           description="Upload Image"
           accept="image/*"
           onChange={fileUploaderProps.handleFileUploadEvent}

--- a/src/app/(tools)/rounded-border/rounded-tool.tsx
+++ b/src/app/(tools)/rounded-border/rounded-tool.tsx
@@ -89,21 +89,21 @@ function useImageConverter(props: {
 }
 
 interface ImageRendererProps {
+  background: BackgroundOption;
+  imageContainer: React.RefObject<HTMLDivElement> | null;
   imageContent: string;
   imageMetadata: { width: number; height: number; name: string };
   radius: Radius | null;
-  background: BackgroundOption;
   setPreviewScale: (scale: number | null) => void;
-  imageContainer: React.RefObject<HTMLDivElement> | null;
 }
 
 const ImageRenderer = ({
+  background,
+  imageContainer,
   imageContent,
   imageMetadata,
   radius,
-  background,
   setPreviewScale,
-  imageContainer,
 }: ImageRendererProps) => {
   const [effectiveBorderRadius, setEffectiveBorderRadius] = useState<number | null>(radius);
   const [internalScale, setInternalScale] = useState<number>(1);
@@ -134,7 +134,10 @@ const ImageRenderer = ({
   }, [imageContent, imageMetadata, radius, imageContainer, setPreviewScale]);
 
   return (
-    <div style={{ backgroundColor: background }}>
+    <div
+      className={background === "transparent" ? "checkerboard" : ""}
+      style={{ backgroundColor: background }}
+    >
       <img
         src={imageContent}
         width={imageMetadata.width * internalScale}
@@ -349,6 +352,7 @@ function RoundedToolCore({
         formatOption={(option) =>
           option.charAt(0).toUpperCase() + option.slice(1)
         }
+        className="w-full"
       />
 
       <div className="flex gap-2">

--- a/src/app/(tools)/rounded-border/rounded-tool.tsx
+++ b/src/app/(tools)/rounded-border/rounded-tool.tsx
@@ -178,7 +178,7 @@ function SaveAsPngButton({
           plausible("convert-image-to-png");
           void convertToPng();
         }}
-        className="flex items-center gap-2 rounded-lg bg-blue-600 h-10 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
+        className="flex items-center gap-2 rounded-lg bg-blue-600 h-10 px-4 py-2 text-sm font-semibold text-white text-left whitespace-nowrap shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
       >
         <DownloadIcon strokeWidth={2.5} />
         Save as PNG
@@ -324,7 +324,7 @@ function RoundedToolCore({
 
       {/* Size Information */}
       <div className="flex flex-col items-center rounded-lg bg-white/5 p-3">
-        <span className="text-sm text-white/60 text-center">Actual Size</span>
+        <span className="text-sm text-white/60 text-center whitespace-nowrap">Actual Size</span>
         <span className="font-medium text-white text-center">
           {imageMetadata.width} × {imageMetadata.height}
         </span>

--- a/src/app/(tools)/rounded-border/rounded-tool.tsx
+++ b/src/app/(tools)/rounded-border/rounded-tool.tsx
@@ -358,7 +358,7 @@ function RoundedToolCore({
       <div className="flex gap-2">
         <button
           onClick={cancel}
-          className="rounded-lg bg-transparent h-10 px-4 py-2 text-sm font-medium text-white/90 transition-colors hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10 focus:bg-white/10"
+          className="rounded-lg bg-transparent h-10 px-4 py-2 text-sm font-medium text-white/90 transition-colors duration-200 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10 focus:bg-white/10"
         >
           Cancel
         </button>

--- a/src/app/(tools)/rounded-border/rounded-tool.tsx
+++ b/src/app/(tools)/rounded-border/rounded-tool.tsx
@@ -10,6 +10,7 @@ import { FetchFromUrlForm } from "@/components/shared/fetch-from-url-form";
 import { FileDropzone } from "@/components/shared/file-dropzone";
 import { ClipboardPasteIcon, DownloadIcon } from "@/components/shared/icons";
 import { OptionSelector } from "@/components/shared/option-selector";
+import { PageTitle } from "@/components/shared/page-title";
 import { PreviewScale } from "@/components/shared/preview-scale";
 import { UploadBox } from "@/components/shared/upload-box";
 
@@ -368,7 +369,7 @@ function RoundedToolCore({
   );
 }
 
-export function RoundedTool() {
+export function RoundedTool({ title }: { title: string }) {
   const [error, setError] = useState<string | null>(null);
   const fileUploaderProps = useFileUploader({ onError: setError });
   const fileFetcherProps = useFileFetcher({ onError: setError });
@@ -380,6 +381,7 @@ export function RoundedTool() {
       setCurrentFile={fileUploaderProps.handleFileUpload}
       onError={setError}
     >
+      <PageTitle title={title} />
       <RoundedToolCore
         fileUploaderProps={fileUploaderProps}
         fileFetcherProps={fileFetcherProps}

--- a/src/app/(tools)/rounded-border/rounded-tool.tsx
+++ b/src/app/(tools)/rounded-border/rounded-tool.tsx
@@ -105,7 +105,9 @@ const ImageRenderer = ({
   radius,
   setPreviewScale,
 }: ImageRendererProps) => {
-  const [effectiveBorderRadius, setEffectiveBorderRadius] = useState<number | null>(radius);
+  const [effectiveBorderRadius, setEffectiveBorderRadius] = useState<
+    number | null
+  >(radius);
   const [internalScale, setInternalScale] = useState<number>(1);
 
   useEffect(() => {
@@ -114,22 +116,22 @@ const ImageRenderer = ({
 
     const updatePreviewScaleFactor = () => {
       const imageContainerWidth = container.clientWidth;
-      
+
       const previewScaleFactor = Math.min(
         imageContainerWidth / imageMetadata.width,
         imageContainerWidth / imageMetadata.height,
-        1 // Prevent upscaling
-      )
+        1, // Prevent upscaling
+      );
 
       setEffectiveBorderRadius((radius ?? 1) * previewScaleFactor);
       setPreviewScale(previewScaleFactor < 1 ? previewScaleFactor : null);
       setInternalScale(previewScaleFactor);
-    }
+    };
 
     updatePreviewScaleFactor();
     const resizeObserver = new ResizeObserver(updatePreviewScaleFactor);
     resizeObserver.observe(container);
-    
+
     return () => resizeObserver.disconnect();
   }, [imageContent, imageMetadata, radius, imageContainer, setPreviewScale]);
 
@@ -182,7 +184,7 @@ function SaveAsPngButton({
           plausible("convert-image-to-png");
           void convertToPng();
         }}
-        className="flex items-center gap-2 rounded-lg bg-blue-600 h-10 px-4 py-2 text-sm font-semibold text-white text-left whitespace-nowrap shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
+        className="flex h-10 items-center gap-2 whitespace-nowrap rounded-lg bg-blue-600 px-4 py-2 text-left text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
       >
         <DownloadIcon strokeWidth={2.5} />
         Save as PNG
@@ -203,9 +205,12 @@ function RoundedToolCore({
   fileFetcherProps,
   error,
   onError,
- }: RoundedToolCoreProps) {
+}: RoundedToolCoreProps) {
   const router = useRouter();
-  const [radius, setRadius] = useLocalStorage<Radius | null>("roundedTool_radius", 2);
+  const [radius, setRadius] = useLocalStorage<Radius | null>(
+    "roundedTool_radius",
+    2,
+  );
   const [isCustomRadius, setIsCustomRadius] = useState(false);
   const [background, setBackground] = useLocalStorage<BackgroundOption>(
     "roundedTool_background",
@@ -213,19 +218,23 @@ function RoundedToolCore({
   );
 
   const imageContainerRef = useRef<HTMLDivElement>(null);
-  const [imageMetadata, setImageMetadata] = useState<ImageMetadata>(fileUploaderProps.imageMetadata);
-  const [imageContent, setImageContent] = useState<string>(fileUploaderProps.imageContent);
+  const [imageMetadata, setImageMetadata] = useState<ImageMetadata>(
+    fileUploaderProps.imageMetadata,
+  );
+  const [imageContent, setImageContent] = useState<string>(
+    fileUploaderProps.imageContent,
+  );
   const [previewScale, setPreviewScale] = useState<number | null>(null);
 
   const SubtitleIcon = <ClipboardPasteIcon className="-ml-1" />;
-  
+
   const cancel = () => {
     fileUploaderProps.cancel();
     fileFetcherProps.cancel();
     setImageMetadata(null);
-    setImageContent('');
+    setImageContent("");
     setPreviewScale(null);
-  }
+  };
 
   const handleRadiusChange = (value: number | "custom") => {
     if (value === "custom") {
@@ -255,7 +264,7 @@ function RoundedToolCore({
       onError(null);
     } else {
       setImageMetadata(null);
-      setImageContent('');
+      setImageContent("");
     }
   }, [
     fileUploaderProps.imageMetadata,
@@ -286,7 +295,7 @@ function RoundedToolCore({
 
   if (!imageMetadata) {
     return (
-      <div className='flex flex-col items-center gap-4'>
+      <div className="flex flex-col items-center gap-4">
         <UploadBox
           title="Add rounded borders to your images. Quick and easy."
           subtitle="Allows pasting images from clipboard"
@@ -311,7 +320,10 @@ function RoundedToolCore({
   return (
     <div className="mx-auto flex max-w-sm flex-col items-center justify-center gap-6 p-8">
       {/* Preview Section */}
-      <div ref={imageContainerRef} className="flex w-full flex-col items-center gap-4 rounded-xl">
+      <div
+        ref={imageContainerRef}
+        className="flex w-full flex-col items-center gap-4 rounded-xl"
+      >
         <PreviewScale previewScale={previewScale} />
         <ImageRenderer
           imageContent={imageContent}
@@ -321,15 +333,17 @@ function RoundedToolCore({
           setPreviewScale={setPreviewScale}
           imageContainer={imageContainerRef as React.RefObject<HTMLDivElement>}
         />
-        <p className="text-lg font-medium text-white/80 break-all">
+        <p className="break-all text-lg font-medium text-white/80">
           {imageMetadata.name}
         </p>
       </div>
 
       {/* Size Information */}
       <div className="flex flex-col items-center rounded-lg bg-white/5 p-3">
-        <span className="text-sm text-white/60 text-center whitespace-nowrap">Actual Size</span>
-        <span className="font-medium text-white text-center">
+        <span className="whitespace-nowrap text-center text-sm text-white/60">
+          Actual Size
+        </span>
+        <span className="text-center font-medium text-white">
           {imageMetadata.width} × {imageMetadata.height}
         </span>
       </div>
@@ -358,7 +372,7 @@ function RoundedToolCore({
       <div className="flex gap-2">
         <button
           onClick={cancel}
-          className="rounded-lg bg-transparent h-10 px-4 py-2 text-sm font-medium text-white/90 transition-colors duration-200 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10 focus:bg-white/10"
+          className="h-10 rounded-lg bg-transparent px-4 py-2 text-sm font-medium text-white/90 transition-colors duration-200 hover:bg-white/10 focus:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10"
         >
           Cancel
         </button>

--- a/src/app/(tools)/rounded-border/rounded-tool.tsx
+++ b/src/app/(tools)/rounded-border/rounded-tool.tsx
@@ -8,6 +8,7 @@ import { ErrorMessage } from "@/components/shared/error-message";
 import { FetchFromUrlForm } from "@/components/shared/fetch-from-url-form";
 import { FileDropzone } from "@/components/shared/file-dropzone";
 import { OptionSelector } from "@/components/shared/option-selector";
+import { PreviewScale } from "@/components/shared/preview-scale";
 import { UploadBox } from "@/components/shared/upload-box";
 
 import { useFileFetcher } from "@/hooks/use-file-fetcher";
@@ -84,37 +85,60 @@ function useImageConverter(props: {
 
 interface ImageRendererProps {
   imageContent: string;
-  radius: Radius;
+  imageMetadata: { width: number; height: number; name: string };
+  radius: Radius | null;
   background: BackgroundOption;
+  setPreviewScale: (scale: number | null) => void;
+  imageContainer: React.RefObject<HTMLDivElement> | null;
 }
 
 const ImageRenderer = ({
   imageContent,
+  imageMetadata,
   radius,
   background,
+  setPreviewScale,
+  imageContainer,
 }: ImageRendererProps) => {
-  const containerRef = useRef<HTMLDivElement>(null);
+  const [effectiveBorderRadius, setEffectiveBorderRadius] = useState<number | null>(radius);
+  const [internalScale, setInternalScale] = useState<number>(1);
 
   useEffect(() => {
-    if (containerRef.current) {
-      const imgElement = containerRef.current.querySelector("img");
-      if (imgElement) {
-        imgElement.style.borderRadius = `${radius}px`;
-      }
+    if (!imageContainer?.current || !imageContent) return;
+    const container = imageContainer.current;
+
+    const updatePreviewScaleFactor = () => {
+      const imageContainerWidth = container.clientWidth;
+      
+      const previewScaleFactor = Math.min(
+        imageContainerWidth / imageMetadata.width,
+        imageContainerWidth / imageMetadata.height,
+        1 // Prevent upscaling
+      )
+
+      setEffectiveBorderRadius((radius ?? 1) * previewScaleFactor);
+      setPreviewScale(previewScaleFactor < 1 ? previewScaleFactor : null);
+      setInternalScale(previewScaleFactor);
     }
-  }, [imageContent, radius]);
+
+    updatePreviewScaleFactor();
+    const resizeObserver = new ResizeObserver(updatePreviewScaleFactor);
+    resizeObserver.observe(container);
+    
+    return () => resizeObserver.disconnect();
+  }, [imageContent, imageMetadata, radius, imageContainer, setPreviewScale]);
 
   return (
-    <div ref={containerRef} className="relative w-[500px]">
-      <div
-        className="absolute inset-0"
-        style={{ backgroundColor: background, borderRadius: 0 }}
-      />
+    <div style={{ backgroundColor: background }}>
       <img
         src={imageContent}
+        width={imageMetadata.width * internalScale}
+        height={imageMetadata.height * internalScale}
         alt="Preview"
-        className="relative rounded-lg"
-        style={{ width: "100%", height: "auto", objectFit: "contain" }}
+        style={{
+          borderRadius: `${effectiveBorderRadius}px`,
+          objectFit: "contain",
+        }}
       />
     </div>
   );
@@ -188,14 +212,17 @@ function RoundedToolCore({
     "transparent",
   );
 
+  const imageContainerRef = useRef<HTMLDivElement>(null);
   const [imageMetadata, setImageMetadata] = useState<ImageMetadata>(fileUploaderProps.imageMetadata);
   const [imageContent, setImageContent] = useState<string>(fileUploaderProps.imageContent);
+  const [previewScale, setPreviewScale] = useState<number | null>(null);
   
   const cancel = () => {
     fileUploaderProps.cancel();
     fileFetcherProps.cancel();
     setImageMetadata(null);
     setImageContent('');
+    setPreviewScale(null);
   }
 
   const handleRadiusChange = (value: number | "custom") => {
@@ -263,11 +290,15 @@ function RoundedToolCore({
   return (
     <div className="mx-auto flex max-w-sm flex-col items-center justify-center gap-6 p-8">
       {/* Preview Section */}
-      <div className="flex w-full flex-col items-center gap-4 rounded-xl">
+      <div ref={imageContainerRef} className="flex w-full flex-col items-center gap-4 rounded-xl">
+        <PreviewScale previewScale={previewScale} />
         <ImageRenderer
           imageContent={imageContent}
+          imageMetadata={imageMetadata}
           radius={radius}
           background={background}
+          setPreviewScale={setPreviewScale}
+          imageContainer={imageContainerRef as React.RefObject<HTMLDivElement>}
         />
         <p className="text-lg font-medium text-white/80 break-all">
           {imageMetadata.name}

--- a/src/app/(tools)/rounded-border/rounded-tool.tsx
+++ b/src/app/(tools)/rounded-border/rounded-tool.tsx
@@ -1,15 +1,21 @@
 "use client";
-import { usePlausible } from "next-plausible";
+
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useLocalStorage } from "@/hooks/use-local-storage";
-import { UploadBox } from "@/components/shared/upload-box";
-import { OptionSelector } from "@/components/shared/option-selector";
+import { usePlausible } from "next-plausible";
+
 import { BorderRadiusSelector } from "@/components/border-radius-selector";
-import {
-  useFileUploader,
-  type FileUploaderResult,
-} from "@/hooks/use-file-uploader";
+import { FetchFromUrlForm } from "@/components/shared/fetch-from-url-form";
 import { FileDropzone } from "@/components/shared/file-dropzone";
+import { OptionSelector } from "@/components/shared/option-selector";
+import { UploadBox } from "@/components/shared/upload-box";
+
+import { useFileFetcher } from "@/hooks/use-file-fetcher";
+import { useFileUploader } from "@/hooks/use-file-uploader";
+import { useLocalStorage } from "@/hooks/use-local-storage";
+
+import { type ImageMetadata } from "@/lib/file-utils";
+import { type FileFetcherResult } from "@/hooks/use-file-fetcher";
+import { type FileUploaderResult } from "@/hooks/use-file-uploader";
 
 type Radius = number;
 
@@ -151,15 +157,31 @@ function SaveAsPngButton({
   );
 }
 
-function RoundedToolCore(props: { fileUploaderProps: FileUploaderResult }) {
-  const { imageContent, imageMetadata, handleFileUploadEvent, cancel } =
-    props.fileUploaderProps;
+type RoundedToolCoreProps = {
+  fileUploaderProps: FileUploaderResult;
+  fileFetcherProps: FileFetcherResult;
+};
+
+function RoundedToolCore({
+  fileUploaderProps,
+  fileFetcherProps,
+ }: RoundedToolCoreProps) {
   const [radius, setRadius] = useLocalStorage<Radius>("roundedTool_radius", 2);
   const [isCustomRadius, setIsCustomRadius] = useState(false);
   const [background, setBackground] = useLocalStorage<BackgroundOption>(
     "roundedTool_background",
     "transparent",
   );
+
+  const [imageMetadata, setImageMetadata] = useState<ImageMetadata>(fileUploaderProps.imageMetadata);
+  const [imageContent, setImageContent] = useState<string>(fileUploaderProps.imageContent);
+  
+  const cancel = () => {
+    fileUploaderProps.cancel();
+    fileFetcherProps.cancel();
+    setImageMetadata(null);
+    setImageContent('');
+  }
 
   const handleRadiusChange = (value: number | "custom") => {
     if (value === "custom") {
@@ -170,15 +192,51 @@ function RoundedToolCore(props: { fileUploaderProps: FileUploaderResult }) {
     }
   };
 
+  useEffect(() => {
+    // Grab metadata and content from method of file upload
+    let metadata: ImageMetadata | null = null;
+    let content: string | null = null;
+
+    if (fileUploaderProps.imageMetadata) {
+      metadata = fileUploaderProps.imageMetadata;
+      content = fileUploaderProps.imageContent;
+    } else {
+      metadata = fileFetcherProps.imageMetadata;
+      content = fileFetcherProps.imageContent;
+    }
+
+    if (metadata) {
+      setImageMetadata(metadata);
+      setImageContent(content);
+    } else {
+      setImageMetadata(null);
+      setImageContent('');
+    }
+  }, [
+    fileUploaderProps.imageMetadata,
+    fileUploaderProps.imageContent,
+    fileFetcherProps.imageMetadata,
+    fileFetcherProps.imageContent,
+  ]);
+
   if (!imageMetadata) {
     return (
-      <UploadBox
-        title="Add rounded borders to your images. Quick and easy."
-        subtitle="Allows pasting images from clipboard"
-        description="Upload Image"
-        accept="image/*"
-        onChange={handleFileUploadEvent}
-      />
+      <div className='flex flex-col items-center gap-4'>
+        <UploadBox
+          title="Add rounded borders to your images. Quick and easy."
+          subtitle="Allows pasting images from clipboard"
+          description="Upload Image"
+          accept="image/*"
+          onChange={fileUploaderProps.handleFileUploadEvent}
+        />
+
+        <FetchFromUrlForm
+          accept="image/*"
+          error={fileFetcherProps.error}
+          pending={fileFetcherProps.pending}
+          handleSubmit={fileFetcherProps.handleFetchFile}
+        />
+      </div>
     );
   }
 
@@ -241,14 +299,18 @@ function RoundedToolCore(props: { fileUploaderProps: FileUploaderResult }) {
 
 export function RoundedTool() {
   const fileUploaderProps = useFileUploader();
+  const fileFetcherProps = useFileFetcher();
 
   return (
     <FileDropzone
-      setCurrentFile={fileUploaderProps.handleFileUpload}
       acceptedFileTypes={["image/*", ".jpg", ".jpeg", ".png", ".webp", ".svg"]}
       dropText="Drop image file"
+      setCurrentFile={fileUploaderProps.handleFileUpload}
     >
-      <RoundedToolCore fileUploaderProps={fileUploaderProps} />
+      <RoundedToolCore
+        fileUploaderProps={fileUploaderProps}
+        fileFetcherProps={fileFetcherProps}
+      />
     </FileDropzone>
   );
 }

--- a/src/app/(tools)/rounded-border/rounded-tool.tsx
+++ b/src/app/(tools)/rounded-border/rounded-tool.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { usePlausible } from "next-plausible";
 
 import { BorderRadiusSelector } from "@/components/border-radius-selector";
+import { ErrorMessage } from "@/components/shared/error-message";
 import { FetchFromUrlForm } from "@/components/shared/fetch-from-url-form";
 import { FileDropzone } from "@/components/shared/file-dropzone";
 import { OptionSelector } from "@/components/shared/option-selector";
@@ -160,11 +161,15 @@ function SaveAsPngButton({
 type RoundedToolCoreProps = {
   fileUploaderProps: FileUploaderResult;
   fileFetcherProps: FileFetcherResult;
+  error: string | null;
+  onError: (error: string | null) => void;
 };
 
 function RoundedToolCore({
   fileUploaderProps,
   fileFetcherProps,
+  error,
+  onError,
  }: RoundedToolCoreProps) {
   const [radius, setRadius] = useLocalStorage<Radius>("roundedTool_radius", 2);
   const [isCustomRadius, setIsCustomRadius] = useState(false);
@@ -208,6 +213,7 @@ function RoundedToolCore({
     if (metadata) {
       setImageMetadata(metadata);
       setImageContent(content);
+      onError(null);
     } else {
       setImageMetadata(null);
       setImageContent('');
@@ -217,6 +223,7 @@ function RoundedToolCore({
     fileUploaderProps.imageContent,
     fileFetcherProps.imageMetadata,
     fileFetcherProps.imageContent,
+    onError,
   ]);
 
   if (!imageMetadata) {
@@ -236,6 +243,8 @@ function RoundedToolCore({
           pending={fileFetcherProps.pending}
           handleSubmit={fileFetcherProps.handleFetchFile}
         />
+
+        {error && <ErrorMessage error={error} />}
       </div>
     );
   }
@@ -298,18 +307,22 @@ function RoundedToolCore({
 }
 
 export function RoundedTool() {
-  const fileUploaderProps = useFileUploader();
-  const fileFetcherProps = useFileFetcher();
+  const [error, setError] = useState<string | null>(null);
+  const fileUploaderProps = useFileUploader({ onError: setError });
+  const fileFetcherProps = useFileFetcher({ onError: setError });
 
   return (
     <FileDropzone
       acceptedFileTypes={["image/*", ".jpg", ".jpeg", ".png", ".webp", ".svg"]}
       dropText="Drop image file"
       setCurrentFile={fileUploaderProps.handleFileUpload}
+      onError={setError}
     >
       <RoundedToolCore
         fileUploaderProps={fileUploaderProps}
         fileFetcherProps={fileFetcherProps}
+        error={error}
+        onError={setError}
       />
     </FileDropzone>
   );

--- a/src/app/(tools)/rounded-border/rounded-tool.tsx
+++ b/src/app/(tools)/rounded-border/rounded-tool.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { usePlausible } from "next-plausible";
 
 import { BorderRadiusSelector } from "@/components/border-radius-selector";
@@ -13,7 +14,9 @@ import { UploadBox } from "@/components/shared/upload-box";
 
 import { useFileFetcher } from "@/hooks/use-file-fetcher";
 import { useFileUploader } from "@/hooks/use-file-uploader";
+import { useKeyDown } from "@/hooks/use-keydown";
 import { useLocalStorage } from "@/hooks/use-local-storage";
+import { isInteractiveElementFocused } from "@/lib/dom-utils";
 
 import { type ImageMetadata } from "@/lib/file-utils";
 import { type FileFetcherResult } from "@/hooks/use-file-fetcher";
@@ -205,6 +208,7 @@ function RoundedToolCore({
   error,
   onError,
  }: RoundedToolCoreProps) {
+  const router = useRouter();
   const [radius, setRadius] = useLocalStorage<Radius>("roundedTool_radius", 2);
   const [isCustomRadius, setIsCustomRadius] = useState(false);
   const [background, setBackground] = useLocalStorage<BackgroundOption>(
@@ -262,6 +266,25 @@ function RoundedToolCore({
     fileFetcherProps.imageContent,
     onError,
   ]);
+
+  // Run the cancel function when the user presses the Escape key on the preview screen,
+  // and navigate back to the home screen when the user presses Escape on the initial tool screen
+  useKeyDown("Escape", () => {
+    if (imageMetadata && imageContent) {
+      // Preview screen
+      if (isInteractiveElementFocused("ALL", ["option", "select"])) {
+        // if any option selector buttons are focused, blur them instead of going back to initial tool screen
+        (document.activeElement as HTMLButtonElement).blur();
+      } else {
+        // otherwise, cancel/go back to initial tool screen
+        cancel();
+      }
+    } else {
+      // Initial tool screen
+      if (isInteractiveElementFocused("INPUT")) return; // ignore if input is focused
+      router.push("/"); // otherwise, return to home screen
+    }
+  });
 
   if (!imageMetadata) {
     return (

--- a/src/app/(tools)/rounded-border/rounded-tool.tsx
+++ b/src/app/(tools)/rounded-border/rounded-tool.tsx
@@ -150,12 +150,22 @@ function SaveAsPngButton({
           plausible("convert-image-to-png");
           void convertToPng();
         }}
-        className="rounded-lg bg-green-700 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-green-800 focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-opacity-75"
+        className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
       >
         Save as PNG
       </button>
     </div>
   );
+}
+
+function ClipboardPasteIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-4 -ml-1 shrink-0">
+      <path d="M15 2H9a1 1 0 0 0-1 1v2c0 .6.4 1 1 1h6c.6 0 1-.4 1-1V3c0-.6-.4-1-1-1Z"/>
+      <path d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2M16 4h2a2 2 0 0 1 2 2v2M11 14h10"/>
+      <path d="m17 10 4 4-4 4"/>
+    </svg>
+  )
 }
 
 type RoundedToolCoreProps = {
@@ -232,6 +242,7 @@ function RoundedToolCore({
         <UploadBox
           title="Add rounded borders to your images. Quick and easy."
           subtitle="Allows pasting images from clipboard"
+          subtitleIcon={ClipboardPasteIcon}
           description="Upload Image"
           accept="image/*"
           onChange={fileUploaderProps.handleFileUploadEvent}
@@ -250,25 +261,28 @@ function RoundedToolCore({
   }
 
   return (
-    <div className="mx-auto flex max-w-2xl flex-col items-center justify-center gap-6 p-6">
-      <div className="flex w-full flex-col items-center gap-4 rounded-xl p-6">
+    <div className="mx-auto flex max-w-sm flex-col items-center justify-center gap-6 p-8">
+      {/* Preview Section */}
+      <div className="flex w-full flex-col items-center gap-4 rounded-xl">
         <ImageRenderer
           imageContent={imageContent}
           radius={radius}
           background={background}
         />
-        <p className="text-lg font-medium text-white/80">
+        <p className="text-lg font-medium text-white/80 break-all">
           {imageMetadata.name}
         </p>
       </div>
 
+      {/* Size Information */}
       <div className="flex flex-col items-center rounded-lg bg-white/5 p-3">
-        <span className="text-sm text-white/60">Original Size</span>
-        <span className="font-medium text-white">
+        <span className="text-sm text-white/60 text-center">Actual Size</span>
+        <span className="font-medium text-white text-center">
           {imageMetadata.width} × {imageMetadata.height}
         </span>
       </div>
 
+      {/* Radius & Background Controls */}
       <BorderRadiusSelector
         title="Border Radius"
         options={[2, 4, 8, 16, 32, 64]}
@@ -291,7 +305,7 @@ function RoundedToolCore({
       <div className="flex gap-3">
         <button
           onClick={cancel}
-          className="rounded-lg bg-red-700 px-4 py-2 text-sm font-medium text-white/90 transition-colors hover:bg-red-800"
+          className="rounded-lg bg-transparent px-4 py-2 text-sm font-medium text-white/90 transition-colors hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10 focus:bg-white/10"
         >
           Cancel
         </button>

--- a/src/app/(tools)/rounded-border/rounded-tool.tsx
+++ b/src/app/(tools)/rounded-border/rounded-tool.tsx
@@ -178,7 +178,7 @@ function SaveAsPngButton({
           plausible("convert-image-to-png");
           void convertToPng();
         }}
-        className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
+        className="flex items-center gap-2 rounded-lg bg-blue-600 h-10 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
       >
         <DownloadIcon strokeWidth={2.5} />
         Save as PNG
@@ -350,10 +350,10 @@ function RoundedToolCore({
         }
       />
 
-      <div className="flex gap-3">
+      <div className="flex gap-2">
         <button
           onClick={cancel}
-          className="rounded-lg bg-transparent px-4 py-2 text-sm font-medium text-white/90 transition-colors hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10 focus:bg-white/10"
+          className="rounded-lg bg-transparent h-10 px-4 py-2 text-sm font-medium text-white/90 transition-colors hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10 focus:bg-white/10"
         >
           Cancel
         </button>

--- a/src/app/(tools)/rounded-border/rounded-tool.tsx
+++ b/src/app/(tools)/rounded-border/rounded-tool.tsx
@@ -209,7 +209,7 @@ function RoundedToolCore({
   onError,
  }: RoundedToolCoreProps) {
   const router = useRouter();
-  const [radius, setRadius] = useLocalStorage<Radius>("roundedTool_radius", 2);
+  const [radius, setRadius] = useLocalStorage<Radius | null>("roundedTool_radius", 2);
   const [isCustomRadius, setIsCustomRadius] = useState(false);
   const [background, setBackground] = useLocalStorage<BackgroundOption>(
     "roundedTool_background",
@@ -340,7 +340,7 @@ function RoundedToolCore({
       <BorderRadiusSelector
         title="Border Radius"
         options={[2, 4, 8, 16, 32, 64]}
-        selected={isCustomRadius ? "custom" : radius}
+        selected={isCustomRadius ? "custom" : (radius ?? 1)}
         onChange={handleRadiusChange}
         customValue={radius}
         onCustomValueChange={setRadius}
@@ -365,7 +365,7 @@ function RoundedToolCore({
         </button>
         <SaveAsPngButton
           imageContent={imageContent}
-          radius={radius}
+          radius={radius ?? 1}
           background={background}
           imageMetadata={imageMetadata}
         />

--- a/src/app/(tools)/square-image/page.tsx
+++ b/src/app/(tools)/square-image/page.tsx
@@ -7,5 +7,5 @@ export const metadata = {
 };
 
 export default function SquareToolPage() {
-  return <SquareTool />;
+  return <SquareTool title={metadata.title} />;
 }

--- a/src/app/(tools)/square-image/square-tool.tsx
+++ b/src/app/(tools)/square-image/square-tool.tsx
@@ -102,7 +102,7 @@ function SaveSquareImageButton({
         plausible("create-square-image");
         handleSaveImage();
       }}
-      className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
+      className="flex items-center gap-2 rounded-lg bg-blue-600 h-10 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
     >
       <DownloadIcon strokeWidth={2.5} />
       Save Image
@@ -292,10 +292,10 @@ function SquareToolCore({
         }
       />
 
-      <div className="flex gap-3">
+      <div className="flex gap-2">
         <button
           onClick={cancel}
-          className="rounded-lg bg-transparent px-4 py-2 text-sm font-medium text-white/60 hover:text-white transition-colors hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10 focus:bg-white/10"
+          className="rounded-lg bg-transparent h-10 px-4 py-2 text-sm font-medium text-white/60 hover:text-white transition-colors hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10 focus:bg-white/10"
         >
           Cancel
         </button>

--- a/src/app/(tools)/square-image/square-tool.tsx
+++ b/src/app/(tools)/square-image/square-tool.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { usePlausible } from "next-plausible";
 
+import { ErrorMessage } from "@/components/shared/error-message";
 import { FetchFromUrlForm } from "@/components/shared/fetch-from-url-form";
 import { FileDropzone } from "@/components/shared/file-dropzone";
 import { OptionSelector } from "@/components/shared/option-selector";
@@ -19,11 +20,15 @@ import { type ImageMetadata } from "@/lib/file-utils";
 type SquareToolCoreProps = {
   fileUploaderProps: FileUploaderResult;
   fileFetcherProps: FileFetcherResult;
+  error: string | null;
+  onError: (error: string | null) => void;
 };
 
 function SquareToolCore({
   fileUploaderProps,
   fileFetcherProps,
+  error,
+  onError,
 }: SquareToolCoreProps) {
   const plausible = usePlausible();
 
@@ -76,6 +81,7 @@ function SquareToolCore({
     if (metadata) {
       setImageMetadata(metadata);
       setImageContent(content);
+      onError(null);
     } else {
       setImageMetadata(null);
       setImageContent('');
@@ -85,6 +91,7 @@ function SquareToolCore({
     fileUploaderProps.imageContent,
     fileFetcherProps.imageMetadata,
     fileFetcherProps.imageContent,
+    onError,
   ]);
 
   useEffect(() => {
@@ -130,6 +137,8 @@ function SquareToolCore({
           pending={fileFetcherProps.pending}
           handleSubmit={fileFetcherProps.handleFetchFile}
         />
+
+        {error && <ErrorMessage error={error} />}
       </div>
     );
   }
@@ -194,18 +203,22 @@ function SquareToolCore({
 }
 
 export function SquareTool() {
-  const fileUploaderProps = useFileUploader();
-  const fileFetcherProps = useFileFetcher();
+  const [error, setError] = useState<string | null>(null);
+  const fileUploaderProps = useFileUploader({ onError: setError });
+  const fileFetcherProps = useFileFetcher({ onError: setError });
 
   return (
     <FileDropzone
       acceptedFileTypes={["image/*", ".jpg", ".jpeg", ".png", ".webp", ".svg"]}
       dropText="Drop image file"
       setCurrentFile={fileUploaderProps.handleFileUpload}
+      onError={setError}
     >
       <SquareToolCore  
         fileUploaderProps={fileUploaderProps}
         fileFetcherProps={fileFetcherProps}
+        error={error}
+        onError={setError}
       />
     </FileDropzone>
   );

--- a/src/app/(tools)/square-image/square-tool.tsx
+++ b/src/app/(tools)/square-image/square-tool.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { usePlausible } from "next-plausible";
 
 import { ErrorMessage } from "@/components/shared/error-message";
 import { FetchFromUrlForm } from "@/components/shared/fetch-from-url-form";
 import { FileDropzone } from "@/components/shared/file-dropzone";
 import { OptionSelector } from "@/components/shared/option-selector";
+import { PreviewScale } from "@/components/shared/preview-scale";
 import { UploadBox } from "@/components/shared/upload-box";
 
 import { useFileFetcher } from "@/hooks/use-file-fetcher";
@@ -16,6 +17,56 @@ import { useLocalStorage } from "@/hooks/use-local-storage";
 import { type FileFetcherResult } from "@/hooks/use-file-fetcher";
 import { type FileUploaderResult } from "@/hooks/use-file-uploader";
 import { type ImageMetadata } from "@/lib/file-utils";
+
+interface ImageRendererProps {
+  imageContent: string | null;
+  imageMetadata: { width: number; height: number; name: string };
+  setPreviewScale: (scale: number | null) => void;
+  imageContainer: React.RefObject<HTMLDivElement> | null;
+}
+
+const ImageRenderer = ({
+  imageContent,
+  imageMetadata,
+  setPreviewScale,
+  imageContainer,
+}: ImageRendererProps) => {
+  const [internalScale, setInternalScale] = useState<number>(1);
+
+  useEffect(() => {
+    if (!imageContainer?.current || !imageContent) return;
+    const container = imageContainer.current;
+
+    const updatePreviewScaleFactor = () => {
+      const imageContainerWidth = container.clientWidth;
+
+      const previewScaleFactor = Math.min(
+        imageContainerWidth / imageMetadata.width,
+        imageContainerWidth / imageMetadata.height,
+        1 // Prevent upscaling
+      );
+
+      setPreviewScale(previewScaleFactor < 1 ? previewScaleFactor : null);
+      setInternalScale(previewScaleFactor);
+    }
+
+    updatePreviewScaleFactor();
+    const resizeObserver = new ResizeObserver(updatePreviewScaleFactor);
+    resizeObserver.observe(container);
+    
+    return () => resizeObserver.disconnect();
+  }, [imageContent, imageMetadata, imageContainer, setPreviewScale]);
+
+  return imageContent ? (
+      <img
+        src={imageContent}
+        width={Math.max(imageMetadata.width, imageMetadata.height) * internalScale}
+        height={Math.max(imageMetadata.width, imageMetadata.height) * internalScale}
+        alt="Preview"
+        style={{ objectFit: "contain" }}
+      />
+  ) : null;
+};
 
 function SaveSquareImageButton({
   imageContent,
@@ -85,14 +136,17 @@ function SquareToolCore({
     null,
   );
 
+  const imageContainerRef = useRef<HTMLDivElement>(null);
   const [imageMetadata, setImageMetadata] = useState<ImageMetadata>(fileUploaderProps.imageMetadata);
   const [imageContent, setImageContent] = useState<string>(fileUploaderProps.imageContent);
+  const [previewScale, setPreviewScale] = useState<number | null>(null);
   
   const cancel = () => {
     fileUploaderProps.cancel();
     fileFetcherProps.cancel();
     setImageMetadata(null);
     setImageContent('');
+    setPreviewScale(null);
   }
 
   useEffect(() => {
@@ -177,10 +231,14 @@ function SquareToolCore({
   return (
     <div className="mx-auto flex max-w-2xl flex-col items-center justify-center gap-6 p-6">
       {/* Preview Section */}
-      <div className="flex w-full flex-col items-center gap-4 rounded-xl">
-        {squareImageContent && (
-          <img src={squareImageContent} alt="Preview" className="mb-4" />
-        )}
+      <div ref={imageContainerRef} className="flex w-full flex-col items-center gap-4 rounded-xl">
+        <PreviewScale previewScale={previewScale} />
+        <ImageRenderer
+          imageContent={squareImageContent}
+          imageMetadata={imageMetadata}
+          setPreviewScale={setPreviewScale}
+          imageContainer={imageContainerRef as React.RefObject<HTMLDivElement>}
+        />
         <p className="text-lg font-medium text-white/80 break-all">
           {imageMetadata.name}
         </p>

--- a/src/app/(tools)/square-image/square-tool.tsx
+++ b/src/app/(tools)/square-image/square-tool.tsx
@@ -28,6 +28,7 @@ interface ImageRendererProps {
   imageContainer: React.RefObject<HTMLDivElement> | null;
   imageContent: string | null;
   imageMetadata: { width: number; height: number; name: string };
+  objectFit: "contain" | "cover";
   setPreviewScale: (scale: number | null) => void;
 }
 
@@ -36,6 +37,7 @@ const ImageRenderer = ({
   imageContainer,
   imageContent,
   imageMetadata,
+  objectFit,
   setPreviewScale,
 }: ImageRendererProps) => {
   const [internalScale, setInternalScale] = useState<number>(1);
@@ -47,11 +49,18 @@ const ImageRenderer = ({
     const updatePreviewScaleFactor = () => {
       const imageContainerWidth = container.clientWidth;
 
-      const previewScaleFactor = Math.min(
-        imageContainerWidth / imageMetadata.width,
-        imageContainerWidth / imageMetadata.height,
-        1, // Prevent upscaling
-      );
+      const previewScaleFactor =
+        objectFit === "contain"
+          ? Math.min(
+              imageContainerWidth / imageMetadata.width,
+              imageContainerWidth / imageMetadata.height,
+              1, // Prevent upscaling
+            )
+          : Math.min(
+              imageContainerWidth /
+                Math.min(imageMetadata.width, imageMetadata.height),
+              1, // Prevent upscaling
+            );
 
       setPreviewScale(previewScaleFactor < 1 ? previewScaleFactor : null);
       setInternalScale(previewScaleFactor);
@@ -62,20 +71,31 @@ const ImageRenderer = ({
     resizeObserver.observe(container);
 
     return () => resizeObserver.disconnect();
-  }, [imageContent, imageMetadata, imageContainer, setPreviewScale]);
+  }, [imageContainer, imageContent, imageMetadata, objectFit, setPreviewScale]);
 
   return imageContent ? (
     <img
       src={imageContent}
-      width={
-        Math.max(imageMetadata.width, imageMetadata.height) * internalScale
-      }
-      height={
-        Math.max(imageMetadata.width, imageMetadata.height) * internalScale
-      }
       alt="Preview"
-      className={backgroundColor === "transparent" ? "checkerboard" : ""}
-      style={{ objectFit: "contain" }}
+      className={`${backgroundColor === "transparent" ? "checkerboard" : ""} size-full max-h-[calc(42rem_-_1.5rem_-_1.5rem)] max-w-[calc(42rem_-_1.5rem_-_1.5rem)]`}
+      style={{
+        objectFit,
+        width: `${
+          objectFit === "contain"
+            ? Math.max(imageMetadata.width, imageMetadata.height) *
+              internalScale
+            : Math.min(imageMetadata.width, imageMetadata.height) *
+              internalScale
+        }px`,
+        height: `${
+          objectFit === "contain"
+            ? Math.max(imageMetadata.width, imageMetadata.height) *
+              internalScale
+            : Math.min(imageMetadata.width, imageMetadata.height) *
+              internalScale
+        }px`,
+        transition: "width 0.2s ease-out, height 0.2s ease-out",
+      }}
     />
   ) : null;
 };
@@ -132,6 +152,11 @@ function SquareToolCore({
   onError,
 }: SquareToolCoreProps) {
   const router = useRouter();
+
+  const [objectFit, setObjectFit] = useLocalStorage<"contain" | "cover">(
+    "squareTool_objectFit",
+    "contain",
+  );
 
   const [backgroundColor, setBackgroundColor] = useLocalStorage<
     "black" | "white" | "transparent"
@@ -192,7 +217,10 @@ function SquareToolCore({
   useEffect(() => {
     if (imageContent && imageMetadata) {
       const canvas = document.createElement("canvas");
-      const size = Math.max(imageMetadata.width, imageMetadata.height);
+      const size =
+        objectFit === "contain"
+          ? Math.max(imageMetadata.width, imageMetadata.height)
+          : Math.min(imageMetadata.width, imageMetadata.height);
       canvas.width = size;
       canvas.height = size;
 
@@ -205,15 +233,44 @@ function SquareToolCore({
 
       // Load and center the image
       const img = new Image();
+
       img.onload = () => {
-        const x = (size - imageMetadata.width) / 2;
-        const y = (size - imageMetadata.height) / 2;
-        ctx.drawImage(img, x, y);
+        const imgAspectRatio = img.width / img.height;
+
+        let w = size;
+        let h = size;
+        let x = 0;
+        let y = 0;
+
+        if (objectFit === "contain") {
+          // Original logic
+          w = imageMetadata.width;
+          h = imageMetadata.height;
+          x = (size - w) / 2;
+          y = (size - h) / 2;
+        } else if (objectFit === "cover") {
+          if (imgAspectRatio > 1) {
+            // Image is wider than square, crop horizontally
+            h = size;
+            w = imgAspectRatio * h;
+            x = (size - w) / 2;
+            y = 0;
+          } else {
+            // Image is taller than square, crop vertically
+            w = size;
+            h = w / imgAspectRatio;
+            y = (size - h) / 2;
+            x = 0;
+          }
+        }
+
+        ctx.drawImage(img, x, y, w, h);
         setSquareImageContent(canvas.toDataURL("image/png"));
       };
+
       img.src = imageContent;
     }
-  }, [imageContent, imageMetadata, backgroundColor]);
+  }, [backgroundColor, imageContent, imageMetadata, objectFit]);
 
   // Run the cancel function when the user presses the Escape key on the preview screen,
   // and navigate back to the home screen when the user presses Escape on the initial tool screen
@@ -271,6 +328,7 @@ function SquareToolCore({
           imageContainer={imageContainerRef as React.RefObject<HTMLDivElement>}
           imageContent={squareImageContent}
           imageMetadata={imageMetadata}
+          objectFit={objectFit}
           setPreviewScale={setPreviewScale}
         />
         <p className="break-all text-lg font-medium text-white/80">
@@ -294,12 +352,28 @@ function SquareToolCore({
             Square Size
           </span>
           <span className="text-center font-medium text-white">
-            {Math.max(imageMetadata.width, imageMetadata.height)}
+            {objectFit === "contain"
+              ? Math.max(imageMetadata.width, imageMetadata.height)
+              : Math.min(imageMetadata.width, imageMetadata.height)}
             {" × "}
-            {Math.max(imageMetadata.width, imageMetadata.height)}
+            {objectFit === "contain"
+              ? Math.max(imageMetadata.width, imageMetadata.height)
+              : Math.min(imageMetadata.width, imageMetadata.height)}
           </span>
         </div>
       </div>
+
+      {/* Object Fit Controls */}
+      <OptionSelector
+        title="Image Fit"
+        options={["contain", "cover"]}
+        selected={objectFit}
+        onChange={setObjectFit}
+        formatOption={(option) =>
+          option.charAt(0).toUpperCase() + option.slice(1)
+        }
+        className="w-full"
+      />
 
       {/* Background Controls */}
       <OptionSelector

--- a/src/app/(tools)/square-image/square-tool.tsx
+++ b/src/app/(tools)/square-image/square-tool.tsx
@@ -24,17 +24,19 @@ import { type FileUploaderResult } from "@/hooks/use-file-uploader";
 import { type ImageMetadata } from "@/lib/file-utils";
 
 interface ImageRendererProps {
+  backgroundColor: "black" | "white" | "transparent";
+  imageContainer: React.RefObject<HTMLDivElement> | null;
   imageContent: string | null;
   imageMetadata: { width: number; height: number; name: string };
   setPreviewScale: (scale: number | null) => void;
-  imageContainer: React.RefObject<HTMLDivElement> | null;
 }
 
 const ImageRenderer = ({
+  backgroundColor,
+  imageContainer,
   imageContent,
   imageMetadata,
   setPreviewScale,
-  imageContainer,
 }: ImageRendererProps) => {
   const [internalScale, setInternalScale] = useState<number>(1);
 
@@ -68,6 +70,7 @@ const ImageRenderer = ({
         width={Math.max(imageMetadata.width, imageMetadata.height) * internalScale}
         height={Math.max(imageMetadata.width, imageMetadata.height) * internalScale}
         alt="Preview"
+        className={backgroundColor === "transparent" ? "checkerboard" : ""}
         style={{ objectFit: "contain" }}
       />
   ) : null;
@@ -253,10 +256,11 @@ function SquareToolCore({
       <div ref={imageContainerRef} className="flex w-full flex-col items-center gap-4 rounded-xl">
         <PreviewScale previewScale={previewScale} />
         <ImageRenderer
+          backgroundColor={backgroundColor}
+          imageContainer={imageContainerRef as React.RefObject<HTMLDivElement>}
           imageContent={squareImageContent}
           imageMetadata={imageMetadata}
           setPreviewScale={setPreviewScale}
-          imageContainer={imageContainerRef as React.RefObject<HTMLDivElement>}
         />
         <p className="text-lg font-medium text-white/80 break-all">
           {imageMetadata.name}

--- a/src/app/(tools)/square-image/square-tool.tsx
+++ b/src/app/(tools)/square-image/square-tool.tsx
@@ -7,6 +7,7 @@ import { usePlausible } from "next-plausible";
 import { ErrorMessage } from "@/components/shared/error-message";
 import { FetchFromUrlForm } from "@/components/shared/fetch-from-url-form";
 import { FileDropzone } from "@/components/shared/file-dropzone";
+import { ClipboardPasteIcon, DownloadIcon } from "@/components/shared/icons";
 import { OptionSelector } from "@/components/shared/option-selector";
 import { PreviewScale } from "@/components/shared/preview-scale";
 import { UploadBox } from "@/components/shared/upload-box";
@@ -101,20 +102,11 @@ function SaveSquareImageButton({
         plausible("create-square-image");
         handleSaveImage();
       }}
-      className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
+      className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
     >
+      <DownloadIcon strokeWidth={2.5} />
       Save Image
     </button>
-  )
-}
-
-function ClipboardPasteIcon() {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-4 -ml-1 shrink-0">
-      <path d="M15 2H9a1 1 0 0 0-1 1v2c0 .6.4 1 1 1h6c.6 0 1-.4 1-1V3c0-.6-.4-1-1-1Z"/>
-      <path d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2M16 4h2a2 2 0 0 1 2 2v2M11 14h10"/>
-      <path d="m17 10 4 4-4 4"/>
-    </svg>
   )
 }
 
@@ -145,6 +137,8 @@ function SquareToolCore({
   const [imageMetadata, setImageMetadata] = useState<ImageMetadata>(fileUploaderProps.imageMetadata);
   const [imageContent, setImageContent] = useState<string>(fileUploaderProps.imageContent);
   const [previewScale, setPreviewScale] = useState<number | null>(null);
+
+  const SubtitleIcon = <ClipboardPasteIcon className="-ml-1" />;
   
   const cancel = () => {
     fileUploaderProps.cancel();
@@ -234,7 +228,7 @@ function SquareToolCore({
         <UploadBox
           title="Create square images with custom backgrounds. Fast and free."
           subtitle="Allows pasting images from clipboard"
-          subtitleIcon={ClipboardPasteIcon}
+          subtitleIcon={SubtitleIcon}
           description="Upload Image"
           accept="image/*"
           onChange={fileUploaderProps.handleFileUploadEvent}

--- a/src/app/(tools)/square-image/square-tool.tsx
+++ b/src/app/(tools)/square-image/square-tool.tsx
@@ -1,19 +1,31 @@
 "use client";
 
-import { usePlausible } from "next-plausible";
-import { useLocalStorage } from "@/hooks/use-local-storage";
-import { UploadBox } from "@/components/shared/upload-box";
-import { OptionSelector } from "@/components/shared/option-selector";
-import { FileDropzone } from "@/components/shared/file-dropzone";
-import {
-  type FileUploaderResult,
-  useFileUploader,
-} from "@/hooks/use-file-uploader";
 import { useEffect, useState } from "react";
+import { usePlausible } from "next-plausible";
 
-function SquareToolCore(props: { fileUploaderProps: FileUploaderResult }) {
-  const { imageContent, imageMetadata, handleFileUploadEvent, cancel } =
-    props.fileUploaderProps;
+import { FetchFromUrlForm } from "@/components/shared/fetch-from-url-form";
+import { FileDropzone } from "@/components/shared/file-dropzone";
+import { OptionSelector } from "@/components/shared/option-selector";
+import { UploadBox } from "@/components/shared/upload-box";
+
+import { useFileFetcher } from "@/hooks/use-file-fetcher";
+import { useFileUploader } from "@/hooks/use-file-uploader";
+import { useLocalStorage } from "@/hooks/use-local-storage";
+
+import { type FileFetcherResult } from "@/hooks/use-file-fetcher";
+import { type FileUploaderResult } from "@/hooks/use-file-uploader";
+import { type ImageMetadata } from "@/lib/file-utils";
+
+type SquareToolCoreProps = {
+  fileUploaderProps: FileUploaderResult;
+  fileFetcherProps: FileFetcherResult;
+};
+
+function SquareToolCore({
+  fileUploaderProps,
+  fileFetcherProps,
+}: SquareToolCoreProps) {
+  const plausible = usePlausible();
 
   const [backgroundColor, setBackgroundColor] = useLocalStorage<
     "black" | "white"
@@ -22,6 +34,58 @@ function SquareToolCore(props: { fileUploaderProps: FileUploaderResult }) {
   const [squareImageContent, setSquareImageContent] = useState<string | null>(
     null,
   );
+
+  const [imageMetadata, setImageMetadata] = useState<ImageMetadata>(fileUploaderProps.imageMetadata);
+  const [imageContent, setImageContent] = useState<string>(fileUploaderProps.imageContent);
+
+  const handleSaveImage = () => {
+    if (squareImageContent && imageMetadata) {
+      const link = document.createElement("a");
+      link.href = squareImageContent;
+      const originalFileName = imageMetadata.name;
+      const fileNameWithoutExtension =
+        originalFileName.substring(0, originalFileName.lastIndexOf(".")) ||
+        originalFileName;
+      link.download = `${fileNameWithoutExtension}-squared.png`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    }
+  };
+  
+  const cancel = () => {
+    fileUploaderProps.cancel();
+    fileFetcherProps.cancel();
+    setImageMetadata(null);
+    setImageContent('');
+  }
+
+  useEffect(() => {
+    // Grab metadata and content from method of file upload
+    let metadata: ImageMetadata | null = null;
+    let content: string | null = null;
+
+    if (fileUploaderProps.imageMetadata) {
+      metadata = fileUploaderProps.imageMetadata;
+      content = fileUploaderProps.imageContent;
+    } else {
+      metadata = fileFetcherProps.imageMetadata;
+      content = fileFetcherProps.imageContent;
+    }
+
+    if (metadata) {
+      setImageMetadata(metadata);
+      setImageContent(content);
+    } else {
+      setImageMetadata(null);
+      setImageContent('');
+    }
+  }, [
+    fileUploaderProps.imageMetadata,
+    fileUploaderProps.imageContent,
+    fileFetcherProps.imageMetadata,
+    fileFetcherProps.imageContent,
+  ]);
 
   useEffect(() => {
     if (imageContent && imageMetadata) {
@@ -49,32 +113,24 @@ function SquareToolCore(props: { fileUploaderProps: FileUploaderResult }) {
     }
   }, [imageContent, imageMetadata, backgroundColor]);
 
-  const handleSaveImage = () => {
-    if (squareImageContent && imageMetadata) {
-      const link = document.createElement("a");
-      link.href = squareImageContent;
-      const originalFileName = imageMetadata.name;
-      const fileNameWithoutExtension =
-        originalFileName.substring(0, originalFileName.lastIndexOf(".")) ||
-        originalFileName;
-      link.download = `${fileNameWithoutExtension}-squared.png`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    }
-  };
-
-  const plausible = usePlausible();
-
   if (!imageMetadata) {
     return (
-      <UploadBox
-        title="Create square images with custom backgrounds. Fast and free."
-        subtitle="Allows pasting images from clipboard"
-        description="Upload Image"
-        accept="image/*"
-        onChange={handleFileUploadEvent}
-      />
+      <div className='flex flex-col items-center gap-4'>
+        <UploadBox
+          title="Create square images with custom backgrounds. Fast and free."
+          subtitle="Allows pasting images from clipboard"
+          description="Upload Image"
+          accept="image/*"
+          onChange={fileUploaderProps.handleFileUploadEvent}
+        />
+
+        <FetchFromUrlForm
+          accept="image/*"
+          error={fileFetcherProps.error}
+          pending={fileFetcherProps.pending}
+          handleSubmit={fileFetcherProps.handleFetchFile}
+        />
+      </div>
     );
   }
 
@@ -139,14 +195,18 @@ function SquareToolCore(props: { fileUploaderProps: FileUploaderResult }) {
 
 export function SquareTool() {
   const fileUploaderProps = useFileUploader();
+  const fileFetcherProps = useFileFetcher();
 
   return (
     <FileDropzone
-      setCurrentFile={fileUploaderProps.handleFileUpload}
       acceptedFileTypes={["image/*", ".jpg", ".jpeg", ".png", ".webp", ".svg"]}
       dropText="Drop image file"
+      setCurrentFile={fileUploaderProps.handleFileUpload}
     >
-      <SquareToolCore fileUploaderProps={fileUploaderProps} />
+      <SquareToolCore  
+        fileUploaderProps={fileUploaderProps}
+        fileFetcherProps={fileFetcherProps}
+      />
     </FileDropzone>
   );
 }

--- a/src/app/(tools)/square-image/square-tool.tsx
+++ b/src/app/(tools)/square-image/square-tool.tsx
@@ -301,7 +301,7 @@ function SquareToolCore({
       <div className="flex gap-2">
         <button
           onClick={cancel}
-          className="rounded-lg bg-transparent h-10 px-4 py-2 text-sm font-medium text-white/60 hover:text-white transition-colors hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10 focus:bg-white/10"
+          className="rounded-lg bg-transparent h-10 px-4 py-2 text-sm font-medium text-white/60 hover:text-white transition-colors duration-200 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10 focus:bg-white/10"
         >
           Cancel
         </button>

--- a/src/app/(tools)/square-image/square-tool.tsx
+++ b/src/app/(tools)/square-image/square-tool.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { usePlausible } from "next-plausible";
 
 import { ErrorMessage } from "@/components/shared/error-message";
@@ -12,7 +13,9 @@ import { UploadBox } from "@/components/shared/upload-box";
 
 import { useFileFetcher } from "@/hooks/use-file-fetcher";
 import { useFileUploader } from "@/hooks/use-file-uploader";
+import { useKeyDown } from "@/hooks/use-keydown";
 import { useLocalStorage } from "@/hooks/use-local-storage";
+import { isInteractiveElementFocused } from "@/lib/dom-utils";
 
 import { type FileFetcherResult } from "@/hooks/use-file-fetcher";
 import { type FileUploaderResult } from "@/hooks/use-file-uploader";
@@ -128,6 +131,8 @@ function SquareToolCore({
   error,
   onError,
 }: SquareToolCoreProps) {
+  const router = useRouter();
+
   const [backgroundColor, setBackgroundColor] = useLocalStorage<
     "black" | "white"
   >("squareTool_backgroundColor", "white");
@@ -203,6 +208,25 @@ function SquareToolCore({
       img.src = imageContent;
     }
   }, [imageContent, imageMetadata, backgroundColor]);
+
+  // Run the cancel function when the user presses the Escape key on the preview screen,
+  // and navigate back to the home screen when the user presses Escape on the initial tool screen
+  useKeyDown("Escape", () => {
+    if (imageMetadata && imageContent) {
+      // Preview screen
+      if (isInteractiveElementFocused("ALL", ["option", "select"])) {
+        // if any option selector buttons are focused, blur them instead of going back to initial tool screen
+        (document.activeElement as HTMLButtonElement).blur();
+      } else {
+        // otherwise, cancel/go back to initial tool screen
+        cancel();
+      }
+    } else {
+      // Initial tool screen
+      if (isInteractiveElementFocused("INPUT")) return; // ignore if input is focused
+      router.push("/"); // otherwise, return to home screen
+    }
+  });
 
   if (!imageMetadata) {
     return (

--- a/src/app/(tools)/square-image/square-tool.tsx
+++ b/src/app/(tools)/square-image/square-tool.tsx
@@ -17,6 +17,53 @@ import { type FileFetcherResult } from "@/hooks/use-file-fetcher";
 import { type FileUploaderResult } from "@/hooks/use-file-uploader";
 import { type ImageMetadata } from "@/lib/file-utils";
 
+function SaveSquareImageButton({
+  imageContent,
+  imageMetadata,
+}: {
+  imageContent: string | null;
+  imageMetadata: { width: number; height: number; name: string };
+}) {
+  const handleSaveImage = () => {
+    if (imageContent && imageMetadata) {
+      const link = document.createElement("a");
+      link.href = imageContent;
+      const originalFileName = imageMetadata.name;
+      const fileNameWithoutExtension =
+        originalFileName.substring(0, originalFileName.lastIndexOf(".")) ||
+        originalFileName;
+      link.download = `${fileNameWithoutExtension}-squared.png`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    }
+  }
+
+  const plausible = usePlausible();
+
+  return (
+    <button
+      onClick={() => {
+        plausible("create-square-image");
+        handleSaveImage();
+      }}
+      className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
+    >
+      Save Image
+    </button>
+  )
+}
+
+function ClipboardPasteIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-4 -ml-1 shrink-0">
+      <path d="M15 2H9a1 1 0 0 0-1 1v2c0 .6.4 1 1 1h6c.6 0 1-.4 1-1V3c0-.6-.4-1-1-1Z"/>
+      <path d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2M16 4h2a2 2 0 0 1 2 2v2M11 14h10"/>
+      <path d="m17 10 4 4-4 4"/>
+    </svg>
+  )
+}
+
 type SquareToolCoreProps = {
   fileUploaderProps: FileUploaderResult;
   fileFetcherProps: FileFetcherResult;
@@ -30,8 +77,6 @@ function SquareToolCore({
   error,
   onError,
 }: SquareToolCoreProps) {
-  const plausible = usePlausible();
-
   const [backgroundColor, setBackgroundColor] = useLocalStorage<
     "black" | "white"
   >("squareTool_backgroundColor", "white");
@@ -42,21 +87,6 @@ function SquareToolCore({
 
   const [imageMetadata, setImageMetadata] = useState<ImageMetadata>(fileUploaderProps.imageMetadata);
   const [imageContent, setImageContent] = useState<string>(fileUploaderProps.imageContent);
-
-  const handleSaveImage = () => {
-    if (squareImageContent && imageMetadata) {
-      const link = document.createElement("a");
-      link.href = squareImageContent;
-      const originalFileName = imageMetadata.name;
-      const fileNameWithoutExtension =
-        originalFileName.substring(0, originalFileName.lastIndexOf(".")) ||
-        originalFileName;
-      link.download = `${fileNameWithoutExtension}-squared.png`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    }
-  };
   
   const cancel = () => {
     fileUploaderProps.cancel();
@@ -126,6 +156,7 @@ function SquareToolCore({
         <UploadBox
           title="Create square images with custom backgrounds. Fast and free."
           subtitle="Allows pasting images from clipboard"
+          subtitleIcon={ClipboardPasteIcon}
           description="Upload Image"
           accept="image/*"
           onChange={fileUploaderProps.handleFileUploadEvent}
@@ -145,32 +176,36 @@ function SquareToolCore({
 
   return (
     <div className="mx-auto flex max-w-2xl flex-col items-center justify-center gap-6 p-6">
-      <div className="flex w-full flex-col items-center gap-4 rounded-xl p-6">
+      {/* Preview Section */}
+      <div className="flex w-full flex-col items-center gap-4 rounded-xl">
         {squareImageContent && (
           <img src={squareImageContent} alt="Preview" className="mb-4" />
         )}
-        <p className="text-lg font-medium text-white/80">
+        <p className="text-lg font-medium text-white/80 break-all">
           {imageMetadata.name}
         </p>
       </div>
 
+      {/* Size Information */}
       <div className="flex gap-6 text-base">
         <div className="flex flex-col items-center rounded-lg bg-white/5 p-3">
-          <span className="text-sm text-white/60">Original</span>
-          <span className="font-medium text-white">
+          <span className="text-sm text-white/60 text-center">Original Size</span>
+          <span className="font-medium text-white text-center">
             {imageMetadata.width} × {imageMetadata.height}
           </span>
         </div>
 
         <div className="flex flex-col items-center rounded-lg bg-white/5 p-3">
-          <span className="text-sm text-white/60">Square Size</span>
-          <span className="font-medium text-white">
-            {Math.max(imageMetadata.width, imageMetadata.height)} ×{" "}
+          <span className="text-sm text-white/60 text-center">Square Size</span>
+          <span className="font-medium text-white text-center">
+            {Math.max(imageMetadata.width, imageMetadata.height)}
+            {" × "}
             {Math.max(imageMetadata.width, imageMetadata.height)}
           </span>
         </div>
       </div>
 
+      {/* Background Controls */}
       <OptionSelector
         title="Background Color"
         options={["white", "black"]}
@@ -184,19 +219,14 @@ function SquareToolCore({
       <div className="flex gap-3">
         <button
           onClick={cancel}
-          className="rounded-lg bg-red-700 px-4 py-2 text-sm font-medium text-white/90 transition-colors hover:bg-red-800"
+          className="rounded-lg bg-transparent px-4 py-2 text-sm font-medium text-white/60 hover:text-white transition-colors hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10 focus:bg-white/10"
         >
           Cancel
         </button>
-        <button
-          onClick={() => {
-            plausible("create-square-image");
-            handleSaveImage();
-          }}
-          className="rounded-lg bg-green-700 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-green-800 focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-opacity-75"
-        >
-          Save Image
-        </button>
+        <SaveSquareImageButton
+          imageContent={squareImageContent}
+          imageMetadata={imageMetadata}
+        />
       </div>
     </div>
   );

--- a/src/app/(tools)/square-image/square-tool.tsx
+++ b/src/app/(tools)/square-image/square-tool.tsx
@@ -102,7 +102,7 @@ function SaveSquareImageButton({
         plausible("create-square-image");
         handleSaveImage();
       }}
-      className="flex items-center gap-2 rounded-lg bg-blue-600 h-10 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
+      className="flex items-center gap-2 rounded-lg bg-blue-600 h-10 px-4 py-2 text-sm font-semibold text-white text-left whitespace-nowrap shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
     >
       <DownloadIcon strokeWidth={2.5} />
       Save Image
@@ -265,14 +265,14 @@ function SquareToolCore({
       {/* Size Information */}
       <div className="flex gap-6 text-base">
         <div className="flex flex-col items-center rounded-lg bg-white/5 p-3">
-          <span className="text-sm text-white/60 text-center">Original Size</span>
+          <span className="text-sm text-white/60 text-center whitespace-nowrap">Original Size</span>
           <span className="font-medium text-white text-center">
             {imageMetadata.width} × {imageMetadata.height}
           </span>
         </div>
 
         <div className="flex flex-col items-center rounded-lg bg-white/5 p-3">
-          <span className="text-sm text-white/60 text-center">Square Size</span>
+          <span className="text-sm text-white/60 text-center whitespace-nowrap">Square Size</span>
           <span className="font-medium text-white text-center">
             {Math.max(imageMetadata.width, imageMetadata.height)}
             {" × "}

--- a/src/app/(tools)/square-image/square-tool.tsx
+++ b/src/app/(tools)/square-image/square-tool.tsx
@@ -50,29 +50,33 @@ const ImageRenderer = ({
       const previewScaleFactor = Math.min(
         imageContainerWidth / imageMetadata.width,
         imageContainerWidth / imageMetadata.height,
-        1 // Prevent upscaling
+        1, // Prevent upscaling
       );
 
       setPreviewScale(previewScaleFactor < 1 ? previewScaleFactor : null);
       setInternalScale(previewScaleFactor);
-    }
+    };
 
     updatePreviewScaleFactor();
     const resizeObserver = new ResizeObserver(updatePreviewScaleFactor);
     resizeObserver.observe(container);
-    
+
     return () => resizeObserver.disconnect();
   }, [imageContent, imageMetadata, imageContainer, setPreviewScale]);
 
   return imageContent ? (
-      <img
-        src={imageContent}
-        width={Math.max(imageMetadata.width, imageMetadata.height) * internalScale}
-        height={Math.max(imageMetadata.width, imageMetadata.height) * internalScale}
-        alt="Preview"
-        className={backgroundColor === "transparent" ? "checkerboard" : ""}
-        style={{ objectFit: "contain" }}
-      />
+    <img
+      src={imageContent}
+      width={
+        Math.max(imageMetadata.width, imageMetadata.height) * internalScale
+      }
+      height={
+        Math.max(imageMetadata.width, imageMetadata.height) * internalScale
+      }
+      alt="Preview"
+      className={backgroundColor === "transparent" ? "checkerboard" : ""}
+      style={{ objectFit: "contain" }}
+    />
   ) : null;
 };
 
@@ -96,7 +100,7 @@ function SaveSquareImageButton({
       link.click();
       document.body.removeChild(link);
     }
-  }
+  };
 
   const plausible = usePlausible();
 
@@ -106,12 +110,12 @@ function SaveSquareImageButton({
         plausible("create-square-image");
         handleSaveImage();
       }}
-      className="flex items-center gap-2 rounded-lg bg-blue-600 h-10 px-4 py-2 text-sm font-semibold text-white text-left whitespace-nowrap shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
+      className="flex h-10 items-center gap-2 whitespace-nowrap rounded-lg bg-blue-600 px-4 py-2 text-left text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
     >
       <DownloadIcon strokeWidth={2.5} />
       Save Image
     </button>
-  )
+  );
 }
 
 type SquareToolCoreProps = {
@@ -138,19 +142,23 @@ function SquareToolCore({
   );
 
   const imageContainerRef = useRef<HTMLDivElement>(null);
-  const [imageMetadata, setImageMetadata] = useState<ImageMetadata>(fileUploaderProps.imageMetadata);
-  const [imageContent, setImageContent] = useState<string>(fileUploaderProps.imageContent);
+  const [imageMetadata, setImageMetadata] = useState<ImageMetadata>(
+    fileUploaderProps.imageMetadata,
+  );
+  const [imageContent, setImageContent] = useState<string>(
+    fileUploaderProps.imageContent,
+  );
   const [previewScale, setPreviewScale] = useState<number | null>(null);
 
   const SubtitleIcon = <ClipboardPasteIcon className="-ml-1" />;
-  
+
   const cancel = () => {
     fileUploaderProps.cancel();
     fileFetcherProps.cancel();
     setImageMetadata(null);
-    setImageContent('');
+    setImageContent("");
     setPreviewScale(null);
-  }
+  };
 
   useEffect(() => {
     // Grab metadata and content from method of file upload
@@ -171,7 +179,7 @@ function SquareToolCore({
       onError(null);
     } else {
       setImageMetadata(null);
-      setImageContent('');
+      setImageContent("");
     }
   }, [
     fileUploaderProps.imageMetadata,
@@ -228,7 +236,7 @@ function SquareToolCore({
 
   if (!imageMetadata) {
     return (
-      <div className='flex flex-col items-center gap-4'>
+      <div className="flex flex-col items-center gap-4">
         <UploadBox
           title="Create square images with custom backgrounds. Fast and free."
           subtitle="Allows pasting images from clipboard"
@@ -253,7 +261,10 @@ function SquareToolCore({
   return (
     <div className="mx-auto flex max-w-2xl flex-col items-center justify-center gap-6 p-6">
       {/* Preview Section */}
-      <div ref={imageContainerRef} className="flex w-full flex-col items-center gap-4 rounded-xl">
+      <div
+        ref={imageContainerRef}
+        className="flex w-full flex-col items-center gap-4 rounded-xl"
+      >
         <PreviewScale previewScale={previewScale} />
         <ImageRenderer
           backgroundColor={backgroundColor}
@@ -262,7 +273,7 @@ function SquareToolCore({
           imageMetadata={imageMetadata}
           setPreviewScale={setPreviewScale}
         />
-        <p className="text-lg font-medium text-white/80 break-all">
+        <p className="break-all text-lg font-medium text-white/80">
           {imageMetadata.name}
         </p>
       </div>
@@ -270,15 +281,19 @@ function SquareToolCore({
       {/* Size Information */}
       <div className="flex gap-6 text-base">
         <div className="flex flex-col items-center rounded-lg bg-white/5 p-3">
-          <span className="text-sm text-white/60 text-center whitespace-nowrap">Original Size</span>
-          <span className="font-medium text-white text-center">
+          <span className="whitespace-nowrap text-center text-sm text-white/60">
+            Original Size
+          </span>
+          <span className="text-center font-medium text-white">
             {imageMetadata.width} × {imageMetadata.height}
           </span>
         </div>
 
         <div className="flex flex-col items-center rounded-lg bg-white/5 p-3">
-          <span className="text-sm text-white/60 text-center whitespace-nowrap">Square Size</span>
-          <span className="font-medium text-white text-center">
+          <span className="whitespace-nowrap text-center text-sm text-white/60">
+            Square Size
+          </span>
+          <span className="text-center font-medium text-white">
             {Math.max(imageMetadata.width, imageMetadata.height)}
             {" × "}
             {Math.max(imageMetadata.width, imageMetadata.height)}
@@ -301,7 +316,7 @@ function SquareToolCore({
       <div className="flex gap-2">
         <button
           onClick={cancel}
-          className="rounded-lg bg-transparent h-10 px-4 py-2 text-sm font-medium text-white/60 hover:text-white transition-colors duration-200 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10 focus:bg-white/10"
+          className="h-10 rounded-lg bg-transparent px-4 py-2 text-sm font-medium text-white/60 transition-colors duration-200 hover:bg-white/10 hover:text-white focus:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10"
         >
           Cancel
         </button>
@@ -327,7 +342,7 @@ export function SquareTool({ title }: { title: string }) {
       onError={setError}
     >
       <PageTitle title={title} />
-      <SquareToolCore  
+      <SquareToolCore
         fileUploaderProps={fileUploaderProps}
         fileFetcherProps={fileFetcherProps}
         error={error}

--- a/src/app/(tools)/square-image/square-tool.tsx
+++ b/src/app/(tools)/square-image/square-tool.tsx
@@ -9,6 +9,7 @@ import { FetchFromUrlForm } from "@/components/shared/fetch-from-url-form";
 import { FileDropzone } from "@/components/shared/file-dropzone";
 import { ClipboardPasteIcon, DownloadIcon } from "@/components/shared/icons";
 import { OptionSelector } from "@/components/shared/option-selector";
+import { PageTitle } from "@/components/shared/page-title";
 import { PreviewScale } from "@/components/shared/preview-scale";
 import { UploadBox } from "@/components/shared/upload-box";
 
@@ -308,7 +309,7 @@ function SquareToolCore({
   );
 }
 
-export function SquareTool() {
+export function SquareTool({ title }: { title: string }) {
   const [error, setError] = useState<string | null>(null);
   const fileUploaderProps = useFileUploader({ onError: setError });
   const fileFetcherProps = useFileFetcher({ onError: setError });
@@ -320,6 +321,7 @@ export function SquareTool() {
       setCurrentFile={fileUploaderProps.handleFileUpload}
       onError={setError}
     >
+      <PageTitle title={title} />
       <SquareToolCore  
         fileUploaderProps={fileUploaderProps}
         fileFetcherProps={fileFetcherProps}

--- a/src/app/(tools)/square-image/square-tool.tsx
+++ b/src/app/(tools)/square-image/square-tool.tsx
@@ -127,7 +127,7 @@ function SquareToolCore({
   const router = useRouter();
 
   const [backgroundColor, setBackgroundColor] = useLocalStorage<
-    "black" | "white"
+    "black" | "white" | "transparent"
   >("squareTool_backgroundColor", "white");
 
   const [squareImageContent, setSquareImageContent] = useState<string | null>(
@@ -285,12 +285,13 @@ function SquareToolCore({
       {/* Background Controls */}
       <OptionSelector
         title="Background Color"
-        options={["white", "black"]}
+        options={["white", "black", "transparent"]}
         selected={backgroundColor}
         onChange={setBackgroundColor}
         formatOption={(option) =>
           option.charAt(0).toUpperCase() + option.slice(1)
         }
+        className="w-full"
       />
 
       <div className="flex gap-2">

--- a/src/app/(tools)/svg-to-png/page.tsx
+++ b/src/app/(tools)/svg-to-png/page.tsx
@@ -6,5 +6,5 @@ export const metadata = {
 };
 
 export default function SVGToolPage() {
-  return <SVGTool />;
+  return <SVGTool title={metadata.title} />;
 }

--- a/src/app/(tools)/svg-to-png/page.tsx
+++ b/src/app/(tools)/svg-to-png/page.tsx
@@ -1,7 +1,7 @@
 import { SVGTool } from "./svg-tool";
 
 export const metadata = {
-  title: "SVG to PNG converter - QuickPic",
+  title: "SVG to PNG Converter - QuickPic",
   description: "Convert SVGs to PNGs. Also makes them bigger.",
 };
 

--- a/src/app/(tools)/svg-to-png/svg-tool.tsx
+++ b/src/app/(tools)/svg-to-png/svg-tool.tsx
@@ -134,12 +134,22 @@ function SaveAsPngButton({
           plausible("convert-svg-to-png");
           void convertToPng();
         }}
-        className="rounded-lg bg-green-700 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-green-800 focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-opacity-75"
+        className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
       >
         Save as PNG
       </button>
     </div>
   );
+}
+
+function ClipboardPasteIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-4 -ml-1 shrink-0">
+      <path d="M15 2H9a1 1 0 0 0-1 1v2c0 .6.4 1 1 1h6c.6 0 1-.4 1-1V3c0-.6-.4-1-1-1Z"/>
+      <path d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2M16 4h2a2 2 0 0 1 2 2v2M11 14h10"/>
+      <path d="m17 10 4 4-4 4"/>
+    </svg>
+  )
 }
 
 type SVGToolCoreProps = {
@@ -218,6 +228,8 @@ function SVGToolCore({
       <div className='flex flex-col items-center gap-4'>
         <UploadBox
           title="Make SVGs into PNGs. Also makes them bigger. (100% free btw.)"
+          subtitle="Allows pasting images from clipboard"
+          subtitleIcon={ClipboardPasteIcon}
           description="Upload SVG"
           accept=".svg"
           onChange={fileUploaderProps.handleFileUploadEvent}
@@ -237,9 +249,9 @@ function SVGToolCore({
   return (
     <div className="mx-auto flex max-w-2xl flex-col items-center justify-center gap-6 p-6">
       {/* Preview Section */}
-      <div className="flex w-full flex-col items-center gap-4 rounded-xl p-6">
+      <div className="w-full flex flex-col items-center gap-4 rounded-xl">
         <SVGRenderer svgContent={rawContent} />
-        <p className="text-lg font-medium text-white/80">
+        <p className="text-lg font-medium text-white/80 break-all">
           {imageMetadata.name}
         </p>
       </div>
@@ -247,16 +259,17 @@ function SVGToolCore({
       {/* Size Information */}
       <div className="flex gap-6 text-base">
         <div className="flex flex-col items-center rounded-lg bg-white/5 p-3">
-          <span className="text-sm text-white/60">Original</span>
-          <span className="font-medium text-white">
+          <span className="text-sm text-white/60 text-center">Original</span>
+          <span className="font-medium text-white text-center">
             {imageMetadata.width} × {imageMetadata.height}
           </span>
         </div>
 
         <div className="flex flex-col items-center rounded-lg bg-white/5 p-3">
-          <span className="text-sm text-white/60">Scaled</span>
-          <span className="font-medium text-white">
-            {imageMetadata.width * effectiveScale} ×{" "}
+          <span className="text-sm text-white/60 text-center">Scaled</span>
+          <span className="font-medium text-white text-center">
+            {imageMetadata.width * effectiveScale}
+            {" × "}
             {imageMetadata.height * effectiveScale}
           </span>
         </div>
@@ -276,7 +289,7 @@ function SVGToolCore({
       <div className="flex gap-3">
         <button
           onClick={cancel}
-          className="rounded-lg bg-red-700 px-4 py-2 text-sm font-medium text-white/90 transition-colors hover:bg-red-800"
+          className="rounded-lg bg-transparent px-4 py-2 text-sm font-medium text-white/60 hover:text-white transition-colors hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10 focus:bg-white/10"
         >
           Cancel
         </button>

--- a/src/app/(tools)/svg-to-png/svg-tool.tsx
+++ b/src/app/(tools)/svg-to-png/svg-tool.tsx
@@ -8,6 +8,7 @@ import { ErrorMessage } from "@/components/shared/error-message";
 import { FetchFromUrlForm } from "@/components/shared/fetch-from-url-form";
 import { FileDropzone } from "@/components/shared/file-dropzone";
 import { ClipboardPasteIcon, DownloadIcon } from "@/components/shared/icons";
+import { PageTitle } from "@/components/shared/page-title";
 import { PreviewScale } from "@/components/shared/preview-scale";
 import { UploadBox } from "@/components/shared/upload-box";
 import { SVGScaleSelector } from "@/components/svg-scale-selector";
@@ -363,7 +364,7 @@ function SVGToolCore({
   );
 }
 
-export function SVGTool() {
+export function SVGTool({ title }: { title: string }) {
   const [error, setError] = useState<string | null>(null);
   const fileUploaderProps = useFileUploader({ accept: [".svg", "image/svg+xml"], onError: setError });
   const fileFetcherProps = useFileFetcher({ onError: setError });
@@ -375,6 +376,7 @@ export function SVGTool() {
       dropText="Drop SVG file"
       onError={setError}
     >
+      <PageTitle title={title} />
       <SVGToolCore
         fileUploaderProps={fileUploaderProps}
         fileFetcherProps={fileFetcherProps}

--- a/src/app/(tools)/svg-to-png/svg-tool.tsx
+++ b/src/app/(tools)/svg-to-png/svg-tool.tsx
@@ -108,7 +108,7 @@ function SVGRenderer({
   imageContent,
   imageMetadata,
   setPreviewScale,
- }: SVGRendererProps) {
+}: SVGRendererProps) {
   const [internalScale, setInternalScale] = useState<number>(1);
 
   useEffect(() => {
@@ -121,17 +121,17 @@ function SVGRenderer({
       const previewScaleFactor = Math.min(
         imageContainerWidth / imageMetadata.width,
         imageContainerWidth / imageMetadata.height,
-        1 // Prevent upscaling
+        1, // Prevent upscaling
       );
 
       setPreviewScale(previewScaleFactor < 1 ? previewScaleFactor : null);
       setInternalScale(previewScaleFactor);
-    }
+    };
 
     updatePreviewScaleFactor();
     const resizeObserver = new ResizeObserver(updatePreviewScaleFactor);
     resizeObserver.observe(container);
-    
+
     return () => resizeObserver.disconnect();
   }, [imageContent, imageMetadata, imageContainer, setPreviewScale]);
 
@@ -142,9 +142,8 @@ function SVGRenderer({
       width={imageMetadata.width * internalScale}
       height={imageMetadata.height * internalScale}
       style={{
-        backgroundColor: backgroundColor === "light"
-          ? "var(--foreground)"
-          : "transparent",
+        backgroundColor:
+          backgroundColor === "light" ? "var(--foreground)" : "transparent",
         objectFit: "contain",
       }}
     />
@@ -178,7 +177,7 @@ function SaveAsPngButton({
           plausible("convert-svg-to-png");
           void convertToPng();
         }}
-        className="flex items-center gap-2 rounded-lg bg-blue-600 h-10 px-4 py-2 text-sm font-semibold text-white text-left whitespace-nowrap shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
+        className="flex h-10 items-center gap-2 whitespace-nowrap rounded-lg bg-blue-600 px-4 py-2 text-left text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
       >
         <DownloadIcon strokeWidth={2.5} />
         Save as PNG
@@ -213,9 +212,15 @@ function SVGToolCore({
   >("svgTool_previewBackgroundColor", "dark");
 
   const imageContainerRef = useRef<HTMLDivElement>(null);
-  const [imageMetadata, setImageMetadata] = useState<ImageMetadata>(fileUploaderProps.imageMetadata);
-  const [imageContent, setImageContent] = useState<string>(fileUploaderProps.imageContent);
-  const [rawContent, setRawContent] = useState<string>(fileUploaderProps.rawContent);
+  const [imageMetadata, setImageMetadata] = useState<ImageMetadata>(
+    fileUploaderProps.imageMetadata,
+  );
+  const [imageContent, setImageContent] = useState<string>(
+    fileUploaderProps.imageContent,
+  );
+  const [rawContent, setRawContent] = useState<string>(
+    fileUploaderProps.rawContent,
+  );
   const [previewScale, setPreviewScale] = useState<number | null>(null);
 
   // Get the actual numeric scale value
@@ -227,10 +232,10 @@ function SVGToolCore({
     fileUploaderProps.cancel();
     fileFetcherProps.cancel();
     setImageMetadata(null);
-    setImageContent('');
-    setRawContent('');
+    setImageContent("");
+    setRawContent("");
     setPreviewScale(null);
-  }
+  };
 
   useEffect(() => {
     // Grab metadata and content from method of file upload
@@ -256,8 +261,8 @@ function SVGToolCore({
       onError(null);
     } else {
       setImageMetadata(null);
-      setImageContent('');
-      setRawContent('');
+      setImageContent("");
+      setRawContent("");
     }
   }, [
     fileUploaderProps.imageMetadata,
@@ -290,7 +295,7 @@ function SVGToolCore({
 
   if (!imageMetadata || !imageContent)
     return (
-      <div className='flex flex-col items-center gap-4'>
+      <div className="flex flex-col items-center gap-4">
         <UploadBox
           title="Make SVGs into PNGs. Also makes them bigger. (100% free btw.)"
           subtitle="Allows pasting images from clipboard"
@@ -314,7 +319,10 @@ function SVGToolCore({
   return (
     <div className="mx-auto flex max-w-2xl flex-col items-center justify-center gap-6 p-6">
       {/* Preview Section */}
-      <div ref={imageContainerRef} className="w-full flex flex-col items-center gap-4 rounded-xl">
+      <div
+        ref={imageContainerRef}
+        className="flex w-full flex-col items-center gap-4 rounded-xl"
+      >
         <PreviewScale previewScale={previewScale} />
         <SVGRenderer
           backgroundColor={previewBackgroundColor}
@@ -323,7 +331,7 @@ function SVGToolCore({
           imageMetadata={imageMetadata}
           setPreviewScale={setPreviewScale}
         />
-        <p className="text-lg font-medium text-white/80 break-all">
+        <p className="break-all text-lg font-medium text-white/80">
           {imageMetadata.name}
         </p>
       </div>
@@ -331,17 +339,19 @@ function SVGToolCore({
       {/* Size Information */}
       <div className="flex gap-6 text-base">
         <div className="flex flex-col items-center rounded-lg bg-white/5 p-3">
-          <span className="text-sm text-white/60 text-center whitespace-nowrap">Original</span>
-          <span className="font-medium text-white text-center">
+          <span className="whitespace-nowrap text-center text-sm text-white/60">
+            Original
+          </span>
+          <span className="text-center font-medium text-white">
             {imageMetadata.width} × {imageMetadata.height}
           </span>
         </div>
 
         <div className="flex flex-col items-center rounded-lg bg-white/5 p-3">
-          <span className="text-sm text-white/60 text-center whitespace-nowrap">
+          <span className="whitespace-nowrap text-center text-sm text-white/60">
             {`Scaled (${formatNumber(effectiveScale)}×)`}
           </span>
-          <span className="font-medium text-white text-center">
+          <span className="text-center font-medium text-white">
             {Math.floor(imageMetadata.width * effectiveScale)}
             {" × "}
             {Math.floor(imageMetadata.height * effectiveScale)}
@@ -375,7 +385,7 @@ function SVGToolCore({
       <div className="flex gap-2">
         <button
           onClick={cancel}
-          className="rounded-lg bg-transparent h-10 px-4 py-2 text-sm font-medium text-white/60 hover:text-white transition-colors duration-200 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10 focus:bg-white/10"
+          className="h-10 rounded-lg bg-transparent px-4 py-2 text-sm font-medium text-white/60 transition-colors duration-200 hover:bg-white/10 hover:text-white focus:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10"
         >
           Cancel
         </button>
@@ -391,7 +401,10 @@ function SVGToolCore({
 
 export function SVGTool({ title }: { title: string }) {
   const [error, setError] = useState<string | null>(null);
-  const fileUploaderProps = useFileUploader({ accept: [".svg", "image/svg+xml"], onError: setError });
+  const fileUploaderProps = useFileUploader({
+    accept: [".svg", "image/svg+xml"],
+    onError: setError,
+  });
   const fileFetcherProps = useFileFetcher({ onError: setError });
 
   return (

--- a/src/app/(tools)/svg-to-png/svg-tool.tsx
+++ b/src/app/(tools)/svg-to-png/svg-tool.tsx
@@ -169,7 +169,7 @@ function SaveAsPngButton({
           plausible("convert-svg-to-png");
           void convertToPng();
         }}
-        className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
+        className="flex items-center gap-2 rounded-lg bg-blue-600 h-10 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
       >
         <DownloadIcon strokeWidth={2.5} />
         Save as PNG
@@ -346,10 +346,10 @@ function SVGToolCore({
       />
 
       {/* Action Buttons */}
-      <div className="flex gap-3">
+      <div className="flex gap-2">
         <button
           onClick={cancel}
-          className="rounded-lg bg-transparent px-4 py-2 text-sm font-medium text-white/60 hover:text-white transition-colors hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10 focus:bg-white/10"
+          className="rounded-lg bg-transparent h-10 px-4 py-2 text-sm font-medium text-white/60 hover:text-white transition-colors hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10 focus:bg-white/10"
         >
           Cancel
         </button>

--- a/src/app/(tools)/svg-to-png/svg-tool.tsx
+++ b/src/app/(tools)/svg-to-png/svg-tool.tsx
@@ -1,10 +1,20 @@
 "use client";
-import { usePlausible } from "next-plausible";
-import { useEffect, useMemo, useRef, useState } from "react";
-import { useLocalStorage } from "@/hooks/use-local-storage";
 
+import { useEffect, useMemo, useRef, useState } from "react";
+import { usePlausible } from "next-plausible";
+
+import { FetchFromUrlForm } from "@/components/shared/fetch-from-url-form";
+import { FileDropzone } from "@/components/shared/file-dropzone";
 import { UploadBox } from "@/components/shared/upload-box";
 import { SVGScaleSelector } from "@/components/svg-scale-selector";
+
+import { useFileFetcher } from "@/hooks/use-file-fetcher";
+import { useFileUploader } from "@/hooks/use-file-uploader";
+import { useLocalStorage } from "@/hooks/use-local-storage";
+
+import { type FileFetcherResult } from "@/hooks/use-file-fetcher";
+import { type FileUploaderResult } from "@/hooks/use-file-uploader";
+import { type ImageMetadata } from "@/lib/file-utils";
 
 export type Scale = "custom" | number;
 
@@ -131,33 +141,88 @@ function SaveAsPngButton({
   );
 }
 
-import {
-  type FileUploaderResult,
-  useFileUploader,
-} from "@/hooks/use-file-uploader";
-import { FileDropzone } from "@/components/shared/file-dropzone";
+type SVGToolCoreProps = {
+  fileUploaderProps: FileUploaderResult;
+  fileFetcherProps: FileFetcherResult;
+};
 
-function SVGToolCore(props: { fileUploaderProps: FileUploaderResult }) {
-  const { rawContent, imageMetadata, handleFileUploadEvent, cancel } =
-    props.fileUploaderProps;
-
+function SVGToolCore({
+  fileUploaderProps,
+  fileFetcherProps,
+}: SVGToolCoreProps) {
   const [scale, setScale] = useLocalStorage<Scale>("svgTool_scale", 1);
   const [customScale, setCustomScale] = useLocalStorage<number>(
     "svgTool_customScale",
     1,
   );
 
+  const [imageMetadata, setImageMetadata] = useState<ImageMetadata>(fileUploaderProps.imageMetadata);
+  const [imageContent, setImageContent] = useState<string>(fileUploaderProps.imageContent);
+  const [rawContent, setRawContent] = useState<string>(fileUploaderProps.rawContent);
+
   // Get the actual numeric scale value
   const effectiveScale = scale === "custom" ? customScale : scale;
 
-  if (!imageMetadata)
+  const cancel = () => {
+    fileUploaderProps.cancel();
+    fileFetcherProps.cancel();
+    setImageMetadata(null);
+    setImageContent('');
+    setRawContent('');
+  }
+
+  useEffect(() => {
+    // Grab metadata and content from method of file upload
+    // Make sure SVG metadata is normalized in case width/height are not explicitly defined
+    let metadata: ImageMetadata | null = null;
+    let content: string | null = null;
+    let raw: string | null = null;
+
+    if (fileUploaderProps.imageMetadata) {
+      metadata = fileUploaderProps.imageMetadata;
+      content = fileUploaderProps.imageContent;
+      raw = fileUploaderProps.rawContent;
+    } else {
+      metadata = fileFetcherProps.imageMetadata;
+      content = fileFetcherProps.imageContent;
+      raw = fileFetcherProps.rawContent;
+    }
+
+    if (metadata) {
+      setImageMetadata(metadata);
+      setImageContent(content);
+      setRawContent(raw);
+    } else {
+      setImageMetadata(null);
+      setImageContent('');
+      setRawContent('');
+    }
+  }, [
+    fileUploaderProps.imageMetadata,
+    fileUploaderProps.imageContent,
+    fileUploaderProps.rawContent,
+    fileFetcherProps.imageMetadata,
+    fileFetcherProps.imageContent,
+    fileFetcherProps.rawContent,
+  ]);
+
+  if (!imageMetadata || !imageContent)
     return (
-      <UploadBox
-        title="Make SVGs into PNGs. Also makes them bigger. (100% free btw.)"
-        description="Upload SVG"
-        accept=".svg"
-        onChange={handleFileUploadEvent}
-      />
+      <div className='flex flex-col items-center gap-4'>
+        <UploadBox
+          title="Make SVGs into PNGs. Also makes them bigger. (100% free btw.)"
+          description="Upload SVG"
+          accept=".svg"
+          onChange={fileUploaderProps.handleFileUploadEvent}
+        />
+
+        <FetchFromUrlForm
+          accept=".svg"
+          error={fileFetcherProps.error}
+          pending={fileFetcherProps.pending}
+          handleSubmit={fileFetcherProps.handleFetchFile}
+        />
+      </div>
     );
 
   return (
@@ -217,14 +282,19 @@ function SVGToolCore(props: { fileUploaderProps: FileUploaderResult }) {
 }
 
 export function SVGTool() {
-  const fileUploaderProps = useFileUploader();
+  const fileUploaderProps = useFileUploader({ accept: [".svg", "image/svg+xml"] });
+  const fileFetcherProps = useFileFetcher();
+
   return (
     <FileDropzone
       setCurrentFile={fileUploaderProps.handleFileUpload}
       acceptedFileTypes={["image/svg+xml", ".svg"]}
       dropText="Drop SVG file"
     >
-      <SVGToolCore fileUploaderProps={fileUploaderProps} />
+      <SVGToolCore
+        fileUploaderProps={fileUploaderProps}
+        fileFetcherProps={fileFetcherProps}
+      />
     </FileDropzone>
   );
 }

--- a/src/app/(tools)/svg-to-png/svg-tool.tsx
+++ b/src/app/(tools)/svg-to-png/svg-tool.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { usePlausible } from "next-plausible";
 
+import { ErrorMessage } from "@/components/shared/error-message";
 import { FetchFromUrlForm } from "@/components/shared/fetch-from-url-form";
 import { FileDropzone } from "@/components/shared/file-dropzone";
 import { UploadBox } from "@/components/shared/upload-box";
@@ -144,11 +145,15 @@ function SaveAsPngButton({
 type SVGToolCoreProps = {
   fileUploaderProps: FileUploaderResult;
   fileFetcherProps: FileFetcherResult;
+  error: string | null;
+  onError: (error: string | null) => void;
 };
 
 function SVGToolCore({
   fileUploaderProps,
   fileFetcherProps,
+  error,
+  onError,
 }: SVGToolCoreProps) {
   const [scale, setScale] = useLocalStorage<Scale>("svgTool_scale", 1);
   const [customScale, setCustomScale] = useLocalStorage<number>(
@@ -192,6 +197,7 @@ function SVGToolCore({
       setImageMetadata(metadata);
       setImageContent(content);
       setRawContent(raw);
+      onError(null);
     } else {
       setImageMetadata(null);
       setImageContent('');
@@ -204,6 +210,7 @@ function SVGToolCore({
     fileFetcherProps.imageMetadata,
     fileFetcherProps.imageContent,
     fileFetcherProps.rawContent,
+    onError,
   ]);
 
   if (!imageMetadata || !imageContent)
@@ -222,6 +229,8 @@ function SVGToolCore({
           pending={fileFetcherProps.pending}
           handleSubmit={fileFetcherProps.handleFetchFile}
         />
+
+        {error && <ErrorMessage error={error} />}
       </div>
     );
 
@@ -282,18 +291,22 @@ function SVGToolCore({
 }
 
 export function SVGTool() {
-  const fileUploaderProps = useFileUploader({ accept: [".svg", "image/svg+xml"] });
-  const fileFetcherProps = useFileFetcher();
+  const [error, setError] = useState<string | null>(null);
+  const fileUploaderProps = useFileUploader({ accept: [".svg", "image/svg+xml"], onError: setError });
+  const fileFetcherProps = useFileFetcher({ onError: setError });
 
   return (
     <FileDropzone
       setCurrentFile={fileUploaderProps.handleFileUpload}
       acceptedFileTypes={["image/svg+xml", ".svg"]}
       dropText="Drop SVG file"
+      onError={setError}
     >
       <SVGToolCore
         fileUploaderProps={fileUploaderProps}
         fileFetcherProps={fileFetcherProps}
+        error={error}
+        onError={setError}
       />
     </FileDropzone>
   );

--- a/src/app/(tools)/svg-to-png/svg-tool.tsx
+++ b/src/app/(tools)/svg-to-png/svg-tool.tsx
@@ -169,7 +169,7 @@ function SaveAsPngButton({
           plausible("convert-svg-to-png");
           void convertToPng();
         }}
-        className="flex items-center gap-2 rounded-lg bg-blue-600 h-10 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
+        className="flex items-center gap-2 rounded-lg bg-blue-600 h-10 px-4 py-2 text-sm font-semibold text-white text-left whitespace-nowrap shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
       >
         <DownloadIcon strokeWidth={2.5} />
         Save as PNG
@@ -317,14 +317,14 @@ function SVGToolCore({
       {/* Size Information */}
       <div className="flex gap-6 text-base">
         <div className="flex flex-col items-center rounded-lg bg-white/5 p-3">
-          <span className="text-sm text-white/60 text-center">Original</span>
+          <span className="text-sm text-white/60 text-center whitespace-nowrap">Original</span>
           <span className="font-medium text-white text-center">
             {imageMetadata.width} × {imageMetadata.height}
           </span>
         </div>
 
         <div className="flex flex-col items-center rounded-lg bg-white/5 p-3">
-          <span className="text-sm text-white/60 text-center">
+          <span className="text-sm text-white/60 text-center whitespace-nowrap">
             {`Scaled (${formatNumber(effectiveScale)}×)`}
           </span>
           <span className="font-medium text-white text-center">

--- a/src/app/(tools)/svg-to-png/svg-tool.tsx
+++ b/src/app/(tools)/svg-to-png/svg-tool.tsx
@@ -6,12 +6,14 @@ import { usePlausible } from "next-plausible";
 import { ErrorMessage } from "@/components/shared/error-message";
 import { FetchFromUrlForm } from "@/components/shared/fetch-from-url-form";
 import { FileDropzone } from "@/components/shared/file-dropzone";
+import { PreviewScale } from "@/components/shared/preview-scale";
 import { UploadBox } from "@/components/shared/upload-box";
 import { SVGScaleSelector } from "@/components/svg-scale-selector";
 
 import { useFileFetcher } from "@/hooks/use-file-fetcher";
 import { useFileUploader } from "@/hooks/use-file-uploader";
 import { useLocalStorage } from "@/hooks/use-local-storage";
+import { formatNumber } from "@/lib/math-utils";
 
 import { type FileFetcherResult } from "@/hooks/use-file-fetcher";
 import { type FileUploaderResult } from "@/hooks/use-file-uploader";
@@ -23,8 +25,8 @@ function scaleSvg(svgContent: string, scale: number) {
   const parser = new DOMParser();
   const svgDoc = parser.parseFromString(svgContent, "image/svg+xml");
   const svgElement = svgDoc.documentElement;
-  const width = parseInt(svgElement.getAttribute("width") ?? "300");
-  const height = parseInt(svgElement.getAttribute("height") ?? "150");
+  const width = parseInt(svgElement.getAttribute("width") ?? "576");
+  const height = parseInt(svgElement.getAttribute("height") ?? "576");
 
   const scaledWidth = width * scale;
   const scaledHeight = height * scale;
@@ -87,24 +89,53 @@ function useSvgConverter(props: {
 }
 
 interface SVGRendererProps {
-  svgContent: string;
+  imageContent: string;
+  imageMetadata: { width: number; height: number; name: string };
+  setPreviewScale: (scale: number | null) => void;
+  imageContainer: React.RefObject<HTMLDivElement> | null;
 }
 
-function SVGRenderer({ svgContent }: SVGRendererProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
+function SVGRenderer({
+  imageContent,
+  imageMetadata,
+  setPreviewScale,
+  imageContainer,
+ }: SVGRendererProps) {
+  const [internalScale, setInternalScale] = useState<number>(1);
 
   useEffect(() => {
-    if (containerRef.current) {
-      containerRef.current.innerHTML = svgContent;
-      const svgElement = containerRef.current.querySelector("svg");
-      if (svgElement) {
-        svgElement.setAttribute("width", "100%");
-        svgElement.setAttribute("height", "100%");
-      }
-    }
-  }, [svgContent]);
+    if (!imageContainer?.current || !imageContent) return;
+    const container = imageContainer.current;
 
-  return <div ref={containerRef} />;
+    const updatePreviewScaleFactor = () => {
+      const imageContainerWidth = container.clientWidth;
+
+      const previewScaleFactor = Math.min(
+        imageContainerWidth / imageMetadata.width,
+        imageContainerWidth / imageMetadata.height,
+        1 // Prevent upscaling
+      );
+
+      setPreviewScale(previewScaleFactor < 1 ? previewScaleFactor : null);
+      setInternalScale(previewScaleFactor);
+    }
+
+    updatePreviewScaleFactor();
+    const resizeObserver = new ResizeObserver(updatePreviewScaleFactor);
+    resizeObserver.observe(container);
+    
+    return () => resizeObserver.disconnect();
+  }, [imageContent, imageMetadata, imageContainer, setPreviewScale]);
+
+  return imageContent ? (
+    <img
+      src={imageContent}
+      alt="Preview"
+      width={imageMetadata.width * internalScale}
+      height={imageMetadata.height * internalScale}
+      style={{ objectFit: "contain" }}
+    />
+  ) : null;
 }
 
 function SaveAsPngButton({
@@ -171,12 +202,14 @@ function SVGToolCore({
     1,
   );
 
+  const imageContainerRef = useRef<HTMLDivElement>(null);
   const [imageMetadata, setImageMetadata] = useState<ImageMetadata>(fileUploaderProps.imageMetadata);
   const [imageContent, setImageContent] = useState<string>(fileUploaderProps.imageContent);
   const [rawContent, setRawContent] = useState<string>(fileUploaderProps.rawContent);
+  const [previewScale, setPreviewScale] = useState<number | null>(null);
 
   // Get the actual numeric scale value
-  const effectiveScale = scale === "custom" ? customScale : scale;
+  const effectiveScale = scale === "custom" ? (customScale ?? 1) : scale;
 
   const cancel = () => {
     fileUploaderProps.cancel();
@@ -184,6 +217,7 @@ function SVGToolCore({
     setImageMetadata(null);
     setImageContent('');
     setRawContent('');
+    setPreviewScale(null);
   }
 
   useEffect(() => {
@@ -249,8 +283,14 @@ function SVGToolCore({
   return (
     <div className="mx-auto flex max-w-2xl flex-col items-center justify-center gap-6 p-6">
       {/* Preview Section */}
-      <div className="w-full flex flex-col items-center gap-4 rounded-xl">
-        <SVGRenderer svgContent={rawContent} />
+      <div ref={imageContainerRef} className="w-full flex flex-col items-center gap-4 rounded-xl">
+        <PreviewScale previewScale={previewScale} />
+        <SVGRenderer
+          imageContent={imageContent}
+          imageMetadata={imageMetadata}
+          setPreviewScale={setPreviewScale}
+          imageContainer={imageContainerRef as React.RefObject<HTMLDivElement>}
+        />
         <p className="text-lg font-medium text-white/80 break-all">
           {imageMetadata.name}
         </p>
@@ -266,11 +306,13 @@ function SVGToolCore({
         </div>
 
         <div className="flex flex-col items-center rounded-lg bg-white/5 p-3">
-          <span className="text-sm text-white/60 text-center">Scaled</span>
+          <span className="text-sm text-white/60 text-center">
+            {`Scaled (${formatNumber(effectiveScale)}×)`}
+          </span>
           <span className="font-medium text-white text-center">
-            {imageMetadata.width * effectiveScale}
+            {Math.floor(imageMetadata.width * effectiveScale)}
             {" × "}
-            {imageMetadata.height * effectiveScale}
+            {Math.floor(imageMetadata.height * effectiveScale)}
           </span>
         </div>
       </div>

--- a/src/app/(tools)/svg-to-png/svg-tool.tsx
+++ b/src/app/(tools)/svg-to-png/svg-tool.tsx
@@ -375,7 +375,7 @@ function SVGToolCore({
       <div className="flex gap-2">
         <button
           onClick={cancel}
-          className="rounded-lg bg-transparent h-10 px-4 py-2 text-sm font-medium text-white/60 hover:text-white transition-colors hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10 focus:bg-white/10"
+          className="rounded-lg bg-transparent h-10 px-4 py-2 text-sm font-medium text-white/60 hover:text-white transition-colors duration-200 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/10 focus:bg-white/10"
         >
           Cancel
         </button>

--- a/src/app/(tools)/svg-to-png/svg-tool.tsx
+++ b/src/app/(tools)/svg-to-png/svg-tool.tsx
@@ -31,8 +31,18 @@ function scaleSvg(svgContent: string, scale: number) {
   const parser = new DOMParser();
   const svgDoc = parser.parseFromString(svgContent, "image/svg+xml");
   const svgElement = svgDoc.documentElement;
-  const width = parseInt(svgElement.getAttribute("width") ?? "576");
-  const height = parseInt(svgElement.getAttribute("height") ?? "576");
+  const viewBox = svgElement.getAttribute("viewBox");
+  let width = parseInt(svgElement.getAttribute("width") ?? "");
+  let height = parseInt(svgElement.getAttribute("height") ?? "");
+
+  // If width and height are not expliclitly defined, extract them from the viewBox attribute
+  if ((!width || !height) && viewBox) {
+    const viewBoxValues = viewBox.split(" ").map(parseFloat);
+    if (viewBoxValues.length === 4) {
+      width = viewBoxValues[2]!;
+      height = viewBoxValues[3]!;
+    }
+  }
 
   const scaledWidth = width * scale;
   const scaledHeight = height * scale;
@@ -45,10 +55,10 @@ function scaleSvg(svgContent: string, scale: number) {
 
 function useSvgConverter(props: {
   canvas: HTMLCanvasElement | null;
-  svgContent: string;
-  scale: number;
   fileName?: string;
   imageMetadata: { width: number; height: number; name: string };
+  scale: number;
+  svgContent: string;
 }) {
   const { width, height, scaledSvg } = useMemo(() => {
     const scaledSvg = scaleSvg(props.svgContent, props.scale);

--- a/src/app/(tools)/svg-to-png/svg-tool.tsx
+++ b/src/app/(tools)/svg-to-png/svg-tool.tsx
@@ -202,7 +202,7 @@ function SVGToolCore({
   const router = useRouter();
   const [scale, setScale] = useLocalStorage<Scale>("svgTool_scale", 1);
 
-  const [customScale, setCustomScale] = useLocalStorage<number>(
+  const [customScale, setCustomScale] = useLocalStorage<number | null>(
     "svgTool_customScale",
     1,
   );
@@ -344,7 +344,7 @@ function SVGToolCore({
       {/* Scale Controls */}
       <SVGScaleSelector
         title="Scale Factor"
-        options={[1, 2, 4, 8, 16, 32, 64]}
+        options={[0.5, 1, 2, 4, 8, 16, 32, 64]}
         selected={scale}
         onChange={setScale}
         customValue={customScale}

--- a/src/app/(tools)/svg-to-png/svg-tool.tsx
+++ b/src/app/(tools)/svg-to-png/svg-tool.tsx
@@ -8,6 +8,7 @@ import { ErrorMessage } from "@/components/shared/error-message";
 import { FetchFromUrlForm } from "@/components/shared/fetch-from-url-form";
 import { FileDropzone } from "@/components/shared/file-dropzone";
 import { ClipboardPasteIcon, DownloadIcon } from "@/components/shared/icons";
+import { OptionSelector } from "@/components/shared/option-selector";
 import { PageTitle } from "@/components/shared/page-title";
 import { PreviewScale } from "@/components/shared/preview-scale";
 import { UploadBox } from "@/components/shared/upload-box";
@@ -94,17 +95,19 @@ function useSvgConverter(props: {
 }
 
 interface SVGRendererProps {
+  backgroundColor: "dark" | "light";
+  imageContainer: React.RefObject<HTMLDivElement> | null;
   imageContent: string;
   imageMetadata: { width: number; height: number; name: string };
   setPreviewScale: (scale: number | null) => void;
-  imageContainer: React.RefObject<HTMLDivElement> | null;
 }
 
 function SVGRenderer({
+  backgroundColor,
+  imageContainer,
   imageContent,
   imageMetadata,
   setPreviewScale,
-  imageContainer,
  }: SVGRendererProps) {
   const [internalScale, setInternalScale] = useState<number>(1);
 
@@ -138,7 +141,12 @@ function SVGRenderer({
       alt="Preview"
       width={imageMetadata.width * internalScale}
       height={imageMetadata.height * internalScale}
-      style={{ objectFit: "contain" }}
+      style={{
+        backgroundColor: backgroundColor === "light"
+          ? "var(--foreground)"
+          : "transparent",
+        objectFit: "contain",
+      }}
     />
   ) : null;
 }
@@ -199,6 +207,10 @@ function SVGToolCore({
     "svgTool_customScale",
     1,
   );
+
+  const [previewBackgroundColor, setPreviewBackgroundColor] = useLocalStorage<
+    "dark" | "light"
+  >("svgTool_previewBackgroundColor", "dark");
 
   const imageContainerRef = useRef<HTMLDivElement>(null);
   const [imageMetadata, setImageMetadata] = useState<ImageMetadata>(fileUploaderProps.imageMetadata);
@@ -305,10 +317,11 @@ function SVGToolCore({
       <div ref={imageContainerRef} className="w-full flex flex-col items-center gap-4 rounded-xl">
         <PreviewScale previewScale={previewScale} />
         <SVGRenderer
+          backgroundColor={previewBackgroundColor}
+          imageContainer={imageContainerRef as React.RefObject<HTMLDivElement>}
           imageContent={imageContent}
           imageMetadata={imageMetadata}
           setPreviewScale={setPreviewScale}
-          imageContainer={imageContainerRef as React.RefObject<HTMLDivElement>}
         />
         <p className="text-lg font-medium text-white/80 break-all">
           {imageMetadata.name}
@@ -344,6 +357,18 @@ function SVGToolCore({
         onChange={setScale}
         customValue={customScale}
         onCustomValueChange={setCustomScale}
+      />
+
+      {/* Preview Background Color Controls */}
+      <OptionSelector
+        title="Background (Preview Only)"
+        options={["dark", "light"]}
+        selected={previewBackgroundColor}
+        onChange={setPreviewBackgroundColor}
+        formatOption={(option: "dark" | "light") =>
+          option.charAt(0).toUpperCase() + option.slice(1)
+        }
+        className="w-full"
       />
 
       {/* Action Buttons */}

--- a/src/app/(tools)/svg-to-png/svg-tool.tsx
+++ b/src/app/(tools)/svg-to-png/svg-tool.tsx
@@ -7,6 +7,7 @@ import { usePlausible } from "next-plausible";
 import { ErrorMessage } from "@/components/shared/error-message";
 import { FetchFromUrlForm } from "@/components/shared/fetch-from-url-form";
 import { FileDropzone } from "@/components/shared/file-dropzone";
+import { ClipboardPasteIcon, DownloadIcon } from "@/components/shared/icons";
 import { PreviewScale } from "@/components/shared/preview-scale";
 import { UploadBox } from "@/components/shared/upload-box";
 import { SVGScaleSelector } from "@/components/svg-scale-selector";
@@ -168,22 +169,13 @@ function SaveAsPngButton({
           plausible("convert-svg-to-png");
           void convertToPng();
         }}
-        className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
+        className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
       >
+        <DownloadIcon strokeWidth={2.5} />
         Save as PNG
       </button>
     </div>
   );
-}
-
-function ClipboardPasteIcon() {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-4 -ml-1 shrink-0">
-      <path d="M15 2H9a1 1 0 0 0-1 1v2c0 .6.4 1 1 1h6c.6 0 1-.4 1-1V3c0-.6-.4-1-1-1Z"/>
-      <path d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2M16 4h2a2 2 0 0 1 2 2v2M11 14h10"/>
-      <path d="m17 10 4 4-4 4"/>
-    </svg>
-  )
 }
 
 type SVGToolCoreProps = {
@@ -215,6 +207,8 @@ function SVGToolCore({
 
   // Get the actual numeric scale value
   const effectiveScale = scale === "custom" ? (customScale ?? 1) : scale;
+
+  const SubtitleIcon = <ClipboardPasteIcon className="-ml-1" />;
 
   const cancel = () => {
     fileUploaderProps.cancel();
@@ -287,7 +281,7 @@ function SVGToolCore({
         <UploadBox
           title="Make SVGs into PNGs. Also makes them bigger. (100% free btw.)"
           subtitle="Allows pasting images from clipboard"
-          subtitleIcon={ClipboardPasteIcon}
+          subtitleIcon={SubtitleIcon}
           description="Upload SVG"
           accept=".svg"
           onChange={fileUploaderProps.handleFileUploadEvent}

--- a/src/app/(tools)/svg-to-png/svg-tool.tsx
+++ b/src/app/(tools)/svg-to-png/svg-tool.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { usePlausible } from "next-plausible";
 
 import { ErrorMessage } from "@/components/shared/error-message";
@@ -12,7 +13,9 @@ import { SVGScaleSelector } from "@/components/svg-scale-selector";
 
 import { useFileFetcher } from "@/hooks/use-file-fetcher";
 import { useFileUploader } from "@/hooks/use-file-uploader";
+import { useKeyDown } from "@/hooks/use-keydown";
 import { useLocalStorage } from "@/hooks/use-local-storage";
+import { isInteractiveElementFocused } from "@/lib/dom-utils";
 import { formatNumber } from "@/lib/math-utils";
 
 import { type FileFetcherResult } from "@/hooks/use-file-fetcher";
@@ -196,7 +199,9 @@ function SVGToolCore({
   error,
   onError,
 }: SVGToolCoreProps) {
+  const router = useRouter();
   const [scale, setScale] = useLocalStorage<Scale>("svgTool_scale", 1);
+
   const [customScale, setCustomScale] = useLocalStorage<number>(
     "svgTool_customScale",
     1,
@@ -256,6 +261,25 @@ function SVGToolCore({
     fileFetcherProps.rawContent,
     onError,
   ]);
+
+  // Run the cancel function when the user presses the Escape key on the preview screen,
+  // and navigate back to the home screen when the user presses Escape on the initial tool screen
+  useKeyDown("Escape", () => {
+    if (imageMetadata && imageContent) {
+      // Preview screen
+      if (isInteractiveElementFocused("ALL", ["option", "select"])) {
+        // if any option selector buttons are focused, blur them instead of going back to initial tool screen
+        (document.activeElement as HTMLButtonElement).blur();
+      } else {
+        // otherwise, cancel/go back to initial tool screen
+        cancel();
+      }
+    } else {
+      // Initial tool screen
+      if (isInteractiveElementFocused("INPUT")) return; // ignore if input is focused
+      router.push("/"); // otherwise, return to home screen
+    }
+  });
 
   if (!imageMetadata || !imageContent)
     return (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,6 +24,6 @@ body {
 
 @layer base {
   .checkerboard {
-    background: repeating-conic-gradient(#fff3 0% 25%, #fff1 0% 50%) 0 / 10px 10px;
+    background: repeating-conic-gradient(#ffffff06 0% 25%, #ffffff0d 0% 50%) 0 / 10px 10px;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,3 +12,12 @@ body {
   background: var(--background);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,3 +21,9 @@ body {
     transform: rotate(360deg);
   }
 }
+
+@layer base {
+  .checkerboard {
+    background: repeating-conic-gradient(#fff3 0% 25%, #fff1 0% 50%) 0 / 10px 10px;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,8 +2,8 @@ import Link from "next/link";
 
 export default function Home() {
   return (
-    <div className="flex min-h-screen flex-col justify-between p-8 font-[family-name:var(--font-geist-sans)] sm:p-20">
-      <main className="flex flex-grow flex-col items-center justify-center">
+    <div className="flex min-h-screen flex-col justify-between px-8 pb-4 font-[family-name:var(--font-geist-sans)]">
+      <main className="flex flex-col grow items-center justify-center text-center">
         <div>
           Hi. I&apos;m{" "}
           <a
@@ -16,16 +16,17 @@ export default function Home() {
           </a>
           . I built these tools because I was annoyed they did not exist.
         </div>
-        <div className="mt-4"></div>
-        <Link href="/svg-to-png" className="text-blue-500 hover:underline">
-          SVG to PNG converter
-        </Link>
-        <Link href="/square-image" className="text-blue-500 hover:underline">
-          Square image generator
-        </Link>
-        <Link href="/rounded-border" className="text-blue-500 hover:underline">
-          Corner Rounder
-        </Link>
+        <div className="flex flex-col gap-2 mt-8">
+          <Link href="/svg-to-png" className="font-medium text-blue-500 hover:text-white focus:text-white focus:outline-0 transition-colors duration-200" tabIndex={0}>
+            SVG to PNG Converter
+          </Link>
+          <Link href="/square-image" className="font-medium text-blue-500 hover:text-white focus:text-white focus:outline-0 transition-colors duration-200" tabIndex={0}>
+            Square Image Generator
+          </Link>
+          <Link href="/rounded-border" className="font-medium text-blue-500 hover:text-white focus:text-white focus:outline-0 transition-colors duration-200" tabIndex={0}>
+            Corner Rounder
+          </Link>
+        </div>
       </main>
       <footer className="mt-8 text-center text-sm text-gray-500">
         <a

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,12 @@
 import Link from "next/link";
 
 import { Footer } from "@/components/shared/footer";
+import {
+  ArrowUpRightIcon,
+  CornerRounderIcon,
+  SquareImageIcon,
+  SvgToPngIcon,
+} from "@/components/shared/icons";
 
 export default function Home() {
   return (
@@ -12,32 +18,36 @@ export default function Home() {
             href="https://twitter.com/t3dotgg"
             target="_blank"
             rel="noopener noreferrer"
-            className="hover:underline"
+            className="inline-flex items-center font-medium text-gray-500 transition-colors duration-200 hover:text-white focus:text-white focus:outline-0"
           >
             Theo
+            <ArrowUpRightIcon />
           </a>
           . I built these tools because I was annoyed they did not exist.
         </div>
-        <div className="mt-8 flex flex-col gap-2">
+        <div className="mt-8 flex flex-col justify-center gap-2">
           <Link
             href="/svg-to-png"
-            className="font-medium text-blue-500 transition-colors duration-200 hover:text-white focus:text-white focus:outline-0"
+            className="inline-flex items-center justify-center gap-2 font-medium text-blue-500 transition-colors duration-200 hover:text-white focus:text-white focus:outline-0"
             tabIndex={0}
           >
+            <SvgToPngIcon />
             SVG to PNG Converter
           </Link>
           <Link
             href="/square-image"
-            className="font-medium text-blue-500 transition-colors duration-200 hover:text-white focus:text-white focus:outline-0"
+            className="inline-flex items-center justify-center gap-2 font-medium text-blue-500 transition-colors duration-200 hover:text-white focus:text-white focus:outline-0"
             tabIndex={0}
           >
+            <SquareImageIcon />
             Square Image Generator
           </Link>
           <Link
             href="/rounded-border"
-            className="font-medium text-blue-500 transition-colors duration-200 hover:text-white focus:text-white focus:outline-0"
+            className="inline-flex items-center justify-center gap-2 font-medium text-blue-500 transition-colors duration-200 hover:text-white focus:text-white focus:outline-0"
             tabIndex={0}
           >
+            <CornerRounderIcon />
             Corner Rounder
           </Link>
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-import { GitHubIcon } from "@/components/shared/icons";
+import { Footer } from "@/components/shared/footer";
 
 export default function Home() {
   return (
@@ -30,17 +30,7 @@ export default function Home() {
           </Link>
         </div>
       </main>
-      <footer className="mt-8 text-center text-sm text-gray-500">
-        <a
-          href="https://github.com/t3dotgg/quickpic"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 font-medium hover:text-gray-200 focus:text-gray-200 transition-colors duration-200"
-        >
-          <GitHubIcon />
-          View on GitHub
-        </a>
-      </footer>
+      <Footer />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import { Footer } from "@/components/shared/footer";
 export default function Home() {
   return (
     <div className="flex min-h-screen flex-col justify-between px-8 pb-4 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col grow items-center justify-center text-center">
+      <main className="flex grow flex-col items-center justify-center text-center">
         <div>
           Hi. I&apos;m{" "}
           <a
@@ -18,14 +18,26 @@ export default function Home() {
           </a>
           . I built these tools because I was annoyed they did not exist.
         </div>
-        <div className="flex flex-col gap-2 mt-8">
-          <Link href="/svg-to-png" className="font-medium text-blue-500 hover:text-white focus:text-white focus:outline-0 transition-colors duration-200" tabIndex={0}>
+        <div className="mt-8 flex flex-col gap-2">
+          <Link
+            href="/svg-to-png"
+            className="font-medium text-blue-500 transition-colors duration-200 hover:text-white focus:text-white focus:outline-0"
+            tabIndex={0}
+          >
             SVG to PNG Converter
           </Link>
-          <Link href="/square-image" className="font-medium text-blue-500 hover:text-white focus:text-white focus:outline-0 transition-colors duration-200" tabIndex={0}>
+          <Link
+            href="/square-image"
+            className="font-medium text-blue-500 transition-colors duration-200 hover:text-white focus:text-white focus:outline-0"
+            tabIndex={0}
+          >
             Square Image Generator
           </Link>
-          <Link href="/rounded-border" className="font-medium text-blue-500 hover:text-white focus:text-white focus:outline-0 transition-colors duration-200" tabIndex={0}>
+          <Link
+            href="/rounded-border"
+            className="font-medium text-blue-500 transition-colors duration-200 hover:text-white focus:text-white focus:outline-0"
+            tabIndex={0}
+          >
             Corner Rounder
           </Link>
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { GitHubIcon } from "@/components/shared/icons";
+
 export default function Home() {
   return (
     <div className="flex min-h-screen flex-col justify-between px-8 pb-4 font-[family-name:var(--font-geist-sans)]">
@@ -33,8 +35,9 @@ export default function Home() {
           href="https://github.com/t3dotgg/quickpic"
           target="_blank"
           rel="noopener noreferrer"
-          className="hover:underline"
+          className="inline-flex items-center gap-1 font-medium hover:text-gray-200 focus:text-gray-200 transition-colors duration-200"
         >
+          <GitHubIcon />
           View on GitHub
         </a>
       </footer>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ import {
 export default function Home() {
   return (
     <div className="flex min-h-screen flex-col justify-between px-8 pb-4 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex grow flex-col items-center justify-center text-center">
+      <main className="mt-[60px] flex grow flex-col items-center justify-center text-center">
         <div>
           Hi. I&apos;m{" "}
           <a

--- a/src/components/border-radius-selector.tsx
+++ b/src/components/border-radius-selector.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect, useRef } from "react";
 
+import { Select } from "@/components/shared/select";
+
+import { useMediaQuery } from "@/hooks/use-media-query";
+
 type CustomValueChangeEventContext = {
   e: React.KeyboardEvent<HTMLInputElement>;
   context: 'keyboard';
@@ -9,22 +13,23 @@ type CustomValueChangeEventContext = {
 }
 
 interface BorderRadiusSelectorProps {
-  title: string;
+  customValue?: number | null;
+  onChange: (value: number | "custom") => void;
+  onCustomValueChange?: (value: number | null) => void;
   options: number[];
   selected: number | "custom";
-  onChange: (value: number | "custom") => void;
-  customValue?: number | null;
-  onCustomValueChange?: (value: number | null) => void;
+  title: string;
 }
 
 export function BorderRadiusSelector({
-  title,
+  customValue,
+  onChange,
+  onCustomValueChange,
   options,
   selected,
-  onChange,
-  customValue,
-  onCustomValueChange,
+  title,
 }: BorderRadiusSelectorProps) {
+  const isXsScreen = useMediaQuery("(max-width: 29rem)");
   const containerRef = useRef<HTMLDivElement>(null);
   const selectedRef = useRef<HTMLButtonElement>(null);
   const highlightRef = useRef<HTMLDivElement>(null);
@@ -114,39 +119,55 @@ export function BorderRadiusSelector({
       highlight.style.left = `${selectedRect.left - containerRect.left}px`;
       highlight.style.width = `${selectedRect.width}px`;
     });
-  }, [selected]);
+
+  // though isXsScreen is not a real dependency, the selected scale option must
+  // be re-rerendered when it changes, because otherwise the highlight will be
+  // missing/not calculated when the user resizes the window and the scale selector
+  // switches between its two different display modes
+  }, [selected, isXsScreen]);
 
   return (
-    <div className="flex flex-col items-center gap-2">
+    <div className={`${isXsScreen ? "w-full" : ""} flex flex-col items-center gap-2`}>
       <span className="text-sm text-white/60">{title}</span>
-      <div className="flex flex-col items-center justify-center gap-2">
-        <div
-          ref={containerRef}
-          className="relative inline-flex rounded-lg bg-white/5 p-1"
-        >
-          <div
-            ref={highlightRef}
-            className="absolute inset-y-1 rounded-md bg-blue-600 transition-all duration-200"
+      <div className={`flex ${isXsScreen ? "flex-row w-full" : "flex-col"} items-center justify-center gap-2`}>
+        {isXsScreen ? (
+          <Select
+            placeholder="Select radius…"
+            options={[ ...options, "custom" as const ]}
+            selected={selected}
+            onChange={onChange}
+            formatOption={(option: number | "custom") => option === "custom" ? "Custom" : `${option}px`}
+            className="flex-1 basis-1/2 w-full min-w-0"
           />
-          {[...options, "custom" as const].map((option) => (
-            <button
-              key={String(option)}
-              ref={option === selected ? selectedRef : null}
-              onClick={() =>
-                onChange(typeof option === "number" ? option : "custom")
-              }
-              className={`option relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-none ${
-                option === selected
-                  ? "text-white"
-                  : "text-white/60 hover:text-white focus:bg-white/10"
-              }`}
-            >
-              {option === "custom" ? "Custom" : option}
-            </button>
-          ))}
-        </div>
+        ) : (
+          <div
+            ref={containerRef}
+            className="relative inline-flex rounded-lg bg-white/5 p-1"
+          >
+            <div
+              ref={highlightRef}
+              className="absolute inset-y-1 rounded-md bg-blue-600 transition-all duration-200"
+            />
+            {[...options, "custom" as const].map((option) => (
+              <button
+                key={String(option)}
+                ref={option === selected ? selectedRef : null}
+                onClick={() =>
+                  onChange(typeof option === "number" ? option : "custom")
+                }
+                className={`option relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-none ${
+                  option === selected
+                    ? "text-white"
+                    : "text-white/60 hover:text-white focus:bg-white/10"
+                }`}
+              >
+                {option === "custom" ? "Custom" : option}
+              </button>
+            ))}
+          </div>
+        )}
         {selected === "custom" && (
-          <div className="w-36 flex items-center gap-2">
+          <div className={`${isXsScreen ? "flex-1 basis-1/2 w-full min-w-0" : "w-36"} flex items-center gap-2`}>
             <div className="group relative flex items-center w-full">
               <input
                 ref={customValueInputRef}

--- a/src/components/border-radius-selector.tsx
+++ b/src/components/border-radius-selector.tsx
@@ -4,13 +4,15 @@ import { Select } from "@/components/shared/select";
 
 import { useMediaQuery } from "@/hooks/use-media-query";
 
-type CustomValueChangeEventContext = {
-  e: React.KeyboardEvent<HTMLInputElement>;
-  context: 'keyboard';
-} | {
-  e: React.MouseEvent<HTMLButtonElement, MouseEvent>;
-  context: 'button-up' | 'button-down';
-}
+type CustomValueChangeEventContext =
+  | {
+      e: React.KeyboardEvent<HTMLInputElement>;
+      context: "keyboard";
+    }
+  | {
+      e: React.MouseEvent<HTMLButtonElement, MouseEvent>;
+      context: "button-up" | "button-down";
+    };
 
 interface BorderRadiusSelectorProps {
   customValue?: number | null;
@@ -45,24 +47,28 @@ export function BorderRadiusSelector({
     if (/^(\d+\.?\d*|\.\d*)?$/.test(rawInput)) {
       onCustomValueChange?.(rawInput === "" ? null : parseFloat(rawInput));
     }
-  }
+  };
 
   // but handle most of the validation on blur, which allows the user to clear the input
   // completely, so they can type anything—including values that begin with "0", like "0.25"
   const handleInputBlur = () => {
     // Empty input and invalid (NaN) input should cause the input to be reset to 1
-    if (customValue === null || customValue === undefined || isNaN(customValue)) {
+    if (
+      customValue === null ||
+      customValue === undefined ||
+      isNaN(customValue)
+    ) {
       onCustomValueChange?.(1);
       return;
     }
-    
+
     // Remove leading and trailing whitespace
     let normalizedValue = customValue.toString().trim();
 
     // Decimal values should always have a single leading zero
     if (normalizedValue.startsWith("."))
       normalizedValue = "0" + normalizedValue;
-    
+
     // Decimal values should always have only one leading zero
     if (/^0+\d+$/.test(normalizedValue))
       normalizedValue = String(parseFloat(normalizedValue));
@@ -75,14 +81,21 @@ export function BorderRadiusSelector({
     if (normalizedValue === "0") normalizedValue = "1";
 
     // Parse the normalized value as a number, clamp it to the range 0 < value < 1000, and set state
-    const clampedValue = Math.min(1000 - Number.EPSILON, Math.max(Number.MIN_VALUE, parseFloat(normalizedValue)));
+    const clampedValue = Math.min(
+      1000 - Number.EPSILON,
+      Math.max(Number.MIN_VALUE, parseFloat(normalizedValue)),
+    );
     onCustomValueChange?.(clampedValue);
-  }
+  };
 
   // a generalized handler for custom value changes which can operate in different contexts—keyboard/keydown
   // on the custom value input itself, or pointer/click on the custom value input's increment/decrement buttons
-  const handleCustomValueStep = ({ e, context }: CustomValueChangeEventContext) => {
-    if (context === 'keyboard' && e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+  const handleCustomValueStep = ({
+    e,
+    context,
+  }: CustomValueChangeEventContext) => {
+    if (context === "keyboard" && e.key !== "ArrowUp" && e.key !== "ArrowDown")
+      return;
 
     e.preventDefault();
     const currentValue = customValue ?? 0.1;
@@ -90,9 +103,9 @@ export function BorderRadiusSelector({
 
     if (e.shiftKey) step = 10;
     if (e.altKey) step = 0.1;
-    
+
     const newValue =
-      (context === 'keyboard' && e.key === "ArrowUp") || (context === 'button-up')
+      (context === "keyboard" && e.key === "ArrowUp") || context === "button-up"
         ? (currentValue || 0) + step
         : (currentValue || 0) - step;
 
@@ -102,10 +115,11 @@ export function BorderRadiusSelector({
     );
 
     onCustomValueChange?.(clampedValue);
-  }
+  };
 
   useEffect(() => {
-    if (!selectedRef.current || !highlightRef.current || !containerRef.current) return;
+    if (!selectedRef.current || !highlightRef.current || !containerRef.current)
+      return;
 
     // prevent layout thrashing
     requestAnimationFrame(() => {
@@ -120,24 +134,30 @@ export function BorderRadiusSelector({
       highlight.style.width = `${selectedRect.width}px`;
     });
 
-  // though isXsScreen is not a real dependency, the selected scale option must
-  // be re-rerendered when it changes, because otherwise the highlight will be
-  // missing/not calculated when the user resizes the window and the scale selector
-  // switches between its two different display modes
+    // though isXsScreen is not a real dependency, the selected scale option must
+    // be re-rerendered when it changes, because otherwise the highlight will be
+    // missing/not calculated when the user resizes the window and the scale selector
+    // switches between its two different display modes
   }, [selected, isXsScreen]);
 
   return (
-    <div className={`${isXsScreen ? "w-full" : ""} flex flex-col items-center gap-2`}>
+    <div
+      className={`${isXsScreen ? "w-full" : ""} flex flex-col items-center gap-2`}
+    >
       <span className="text-sm text-white/60">{title}</span>
-      <div className={`flex ${isXsScreen ? "flex-row w-full" : "flex-col"} items-center justify-center gap-2`}>
+      <div
+        className={`flex ${isXsScreen ? "w-full flex-row" : "flex-col"} items-center justify-center gap-2`}
+      >
         {isXsScreen ? (
           <Select
             placeholder="Select radius…"
-            options={[ ...options, "custom" as const ]}
+            options={[...options, "custom" as const]}
             selected={selected}
             onChange={onChange}
-            formatOption={(option: number | "custom") => option === "custom" ? "Custom" : `${option}px`}
-            className="flex-1 basis-1/2 w-full min-w-0"
+            formatOption={(option: number | "custom") =>
+              option === "custom" ? "Custom" : `${option}px`
+            }
+            className="w-full min-w-0 flex-1 basis-1/2"
           />
         ) : (
           <div
@@ -155,7 +175,7 @@ export function BorderRadiusSelector({
                 onClick={() =>
                   onChange(typeof option === "number" ? option : "custom")
                 }
-                className={`option relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-none ${
+                className={`option focus:ring-none relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none ${
                   option === selected
                     ? "text-white"
                     : "text-white/60 hover:text-white focus:bg-white/10"
@@ -167,8 +187,10 @@ export function BorderRadiusSelector({
           </div>
         )}
         {selected === "custom" && (
-          <div className={`${isXsScreen ? "flex-1 basis-1/2 w-full min-w-0" : "w-36"} flex items-center gap-2`}>
-            <div className="group relative flex items-center w-full">
+          <div
+            className={`${isXsScreen ? "w-full min-w-0 flex-1 basis-1/2" : "w-36"} flex items-center gap-2`}
+          >
+            <div className="group relative flex w-full items-center">
               <input
                 ref={customValueInputRef}
                 type="number"
@@ -178,38 +200,74 @@ export function BorderRadiusSelector({
                 value={customValue === null ? "" : customValue}
                 onChange={handleInputChange}
                 onBlur={handleInputBlur}
-                onKeyDown={(e) => handleCustomValueStep({ e, context: 'keyboard' })}
-                className="w-full h-10 rounded-lg px-3 pr-[50px] py-2 text-sm font-medium bg-white/5 text-white/60 group-hover:text-white group-focus-within:text-white placeholder:text-gray-500 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 focus-visible:ring-offset-none group-focus-within:ring-2 group-focus-within:ring-white/30 disabled:cursor-not-allowed disabled:opacity-50 [&::-webkit-inner-spin-button]:[-webkit-appearance:none] [&::-webkit-outer-spin-button]:[-webkit-appearance:none] [&::-webkit-inner-spin-button]:opacity-0 [&::-webkit-outer-spin-button]:opacity-0"
+                onKeyDown={(e) =>
+                  handleCustomValueStep({ e, context: "keyboard" })
+                }
+                className="focus-visible:ring-offset-none h-10 w-full rounded-lg bg-white/5 px-3 py-2 pr-[50px] text-sm font-medium text-white/60 transition-colors duration-200 placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 disabled:cursor-not-allowed disabled:opacity-50 group-focus-within:text-white group-focus-within:ring-2 group-focus-within:ring-white/30 group-hover:text-white [&::-webkit-inner-spin-button]:opacity-0 [&::-webkit-inner-spin-button]:[-webkit-appearance:none] [&::-webkit-outer-spin-button]:opacity-0 [&::-webkit-outer-spin-button]:[-webkit-appearance:none]"
                 placeholder="Enter radius"
               />
-              <span className="absolute right-8 font-medium text-sm text-gray-500">px</span>
+              <span className="absolute right-8 text-sm font-medium text-gray-500">
+                px
+              </span>
               <button
                 ref={customValueIncrementRef}
-                className="absolute right-2 top-2 flex items-center justify-center w-4 h-3 cursor-pointer transition-colors text-gray-500 hover:text-white focus:rounded-sm focus:outline-none focus:ring-none focus:text-white focus:bg-white/10"
-                onClick={(e) => handleCustomValueStep({ e, context: 'button-up' })}
+                className="focus:ring-none absolute right-2 top-2 flex h-3 w-4 cursor-pointer items-center justify-center text-gray-500 transition-colors hover:text-white focus:rounded-sm focus:bg-white/10 focus:text-white focus:outline-none"
+                onClick={(e) =>
+                  handleCustomValueStep({ e, context: "button-up" })
+                }
                 onMouseLeave={() => {
                   // prevent increment/decrement buttons from retaining focus after click and even after mouseleave
-                  if (document.activeElement === customValueIncrementRef.current) {
+                  if (
+                    document.activeElement === customValueIncrementRef.current
+                  ) {
                     customValueIncrementRef.current?.blur();
                     customValueInputRef.current?.focus();
                   }
                 }}
               >
-                <svg xmlns="http://www.w3.org/2000/svg" width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="m18 15-6-6-6 6"/></svg>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width={16}
+                  height={16}
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="m18 15-6-6-6 6" />
+                </svg>
               </button>
               <button
                 ref={customValueDecrementRef}
-                className="absolute right-2 bottom-2 flex items-center justify-center w-4 h-3 cursor-pointer transition-colors text-gray-500 hover:text-white focus:rounded-sm focus:outline-none focus:ring-none focus:text-white focus:bg-white/10"
-                onClick={(e) => handleCustomValueStep({ e, context: 'button-down' })}
+                className="focus:ring-none absolute bottom-2 right-2 flex h-3 w-4 cursor-pointer items-center justify-center text-gray-500 transition-colors hover:text-white focus:rounded-sm focus:bg-white/10 focus:text-white focus:outline-none"
+                onClick={(e) =>
+                  handleCustomValueStep({ e, context: "button-down" })
+                }
                 onMouseLeave={() => {
                   // prevent increment/decrement buttons from retaining focus after click and even after mouseleave
-                  if (document.activeElement === customValueDecrementRef.current) {
+                  if (
+                    document.activeElement === customValueDecrementRef.current
+                  ) {
                     customValueDecrementRef.current?.blur();
                     customValueInputRef.current?.focus();
                   }
                 }}
               >
-                <svg xmlns="http://www.w3.org/2000/svg" width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width={16}
+                  height={16}
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="m6 9 6 6 6-6" />
+                </svg>
               </button>
             </div>
           </div>

--- a/src/components/border-radius-selector.tsx
+++ b/src/components/border-radius-selector.tsx
@@ -77,8 +77,11 @@ export function BorderRadiusSelector({
     if (normalizedValue.includes("."))
       normalizedValue = parseFloat(normalizedValue).toString();
 
-    // Values of 0 should be normalized to 1
+    // Values of 0 should be normalized to 1, while still allowing values arbitrarily close to 0
     if (normalizedValue === "0") normalizedValue = "1";
+
+    // Values of 1000 and above should be normalized to 999, while still allowing values arbitrarily close to 1000
+    if (+normalizedValue >= 1000) normalizedValue = "999";
 
     // Parse the normalized value as a number, clamp it to the range 0 < value < 1000, and set state
     const clampedValue = Math.min(

--- a/src/components/border-radius-selector.tsx
+++ b/src/components/border-radius-selector.tsx
@@ -1,12 +1,20 @@
-import React, { useRef, useEffect } from "react";
+import React, { useEffect, useRef } from "react";
+
+type CustomValueChangeEventContext = {
+  e: React.KeyboardEvent<HTMLInputElement>;
+  context: 'keyboard';
+} | {
+  e: React.MouseEvent<HTMLButtonElement, MouseEvent>;
+  context: 'button-up' | 'button-down';
+}
 
 interface BorderRadiusSelectorProps {
   title: string;
   options: number[];
   selected: number | "custom";
   onChange: (value: number | "custom") => void;
-  customValue?: number;
-  onCustomValueChange?: (value: number) => void;
+  customValue?: number | null;
+  onCustomValueChange?: (value: number | null) => void;
 }
 
 export function BorderRadiusSelector({
@@ -20,50 +28,98 @@ export function BorderRadiusSelector({
   const containerRef = useRef<HTMLDivElement>(null);
   const selectedRef = useRef<HTMLButtonElement>(null);
   const highlightRef = useRef<HTMLDivElement>(null);
+  const customValueInputRef = useRef<HTMLInputElement>(null);
+  const customValueIncrementRef = useRef<HTMLButtonElement>(null);
+  const customValueDecrementRef = useRef<HTMLButtonElement>(null);
+
+  // handle basic validation on the change event
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const rawInput = e.target.value;
+
+    // If the input is a valid number, set state (empty string should become null)
+    if (/^(\d+\.?\d*|\.\d*)?$/.test(rawInput)) {
+      onCustomValueChange?.(rawInput === "" ? null : parseFloat(rawInput));
+    }
+  }
+
+  // but handle most of the validation on blur, which allows the user to clear the input
+  // completely, so they can type anything—including values that begin with "0", like "0.25"
+  const handleInputBlur = () => {
+    // Empty input and invalid (NaN) input should cause the input to be reset to 1
+    if (customValue === null || customValue === undefined || isNaN(customValue)) {
+      onCustomValueChange?.(1);
+      return;
+    }
+    
+    // Remove leading and trailing whitespace
+    let normalizedValue = customValue.toString().trim();
+
+    // Decimal values should always have a single leading zero
+    if (normalizedValue.startsWith("."))
+      normalizedValue = "0" + normalizedValue;
+    
+    // Decimal values should always have only one leading zero
+    if (/^0+\d+$/.test(normalizedValue))
+      normalizedValue = String(parseFloat(normalizedValue));
+
+    // Decimal values should never have trailing zeroes
+    if (normalizedValue.includes("."))
+      normalizedValue = parseFloat(normalizedValue).toString();
+
+    // Values of 0 should be normalized to 1
+    if (normalizedValue === "0") normalizedValue = "1";
+
+    // Parse the normalized value as a number, clamp it to the range 0 < value < 1000, and set state
+    const clampedValue = Math.min(1000 - Number.EPSILON, Math.max(Number.MIN_VALUE, parseFloat(normalizedValue)));
+    onCustomValueChange?.(clampedValue);
+  }
+
+  // a generalized handler for custom value changes which can operate in different contexts—keyboard/keydown
+  // on the custom value input itself, or pointer/click on the custom value input's increment/decrement buttons
+  const handleCustomValueStep = ({ e, context }: CustomValueChangeEventContext) => {
+    if (context === 'keyboard' && e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+
+    e.preventDefault();
+    const currentValue = customValue ?? 0.1;
+    let step = 1;
+
+    if (e.shiftKey) step = 10;
+    if (e.altKey) step = 0.1;
+    
+    const newValue =
+      (context === 'keyboard' && e.key === "ArrowUp") || (context === 'button-up')
+        ? (currentValue || 0) + step
+        : (currentValue || 0) - step;
+
+    const clampedValue = Math.min(
+      e.altKey ? 999.9 : 999,
+      Math.max(e.altKey ? 0.1 : 1, Number(newValue.toFixed(1))),
+    );
+
+    onCustomValueChange?.(clampedValue);
+  }
 
   useEffect(() => {
-    if (selectedRef.current && highlightRef.current && containerRef.current) {
-      const container = containerRef.current;
-      const selected = selectedRef.current;
-      const highlight = highlightRef.current;
+    if (!selectedRef.current || !highlightRef.current || !containerRef.current) return;
+
+    // prevent layout thrashing
+    requestAnimationFrame(() => {
+      const container = containerRef.current!;
+      const selected = selectedRef.current!;
+      const highlight = highlightRef.current!;
 
       const containerRect = container.getBoundingClientRect();
       const selectedRect = selected.getBoundingClientRect();
 
       highlight.style.left = `${selectedRect.left - containerRect.left}px`;
       highlight.style.width = `${selectedRect.width}px`;
-    }
+    });
   }, [selected]);
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = Math.min(999, Math.max(0, parseInt(e.target.value) || 0));
-    onCustomValueChange?.(value);
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
-
-    e.preventDefault();
-    const currentValue = customValue ?? 0;
-    let step = 1;
-
-    if (e.shiftKey) step = 10;
-    if (e.altKey) step = 0.1;
-
-    const newValue =
-      e.key === "ArrowUp" ? currentValue + step : currentValue - step;
-
-    const clampedValue = Math.min(
-      999,
-      Math.max(0, Number(newValue.toFixed(1))),
-    );
-    onCustomValueChange?.(clampedValue);
-  };
 
   return (
     <div className="flex flex-col items-center gap-2">
       <span className="text-sm text-white/60">{title}</span>
-      <div className="flex flex-col items-center gap-2">
+      <div className="flex flex-col items-center justify-center gap-2">
         <div
           ref={containerRef}
           className="relative inline-flex rounded-lg bg-white/5 p-1"
@@ -79,10 +135,10 @@ export function BorderRadiusSelector({
               onClick={() =>
                 onChange(typeof option === "number" ? option : "custom")
               }
-              className={`relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+              className={`option relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-none ${
                 option === selected
                   ? "text-white"
-                  : "text-white/80 hover:text-white"
+                  : "text-white/60 hover:text-white focus:bg-white/10"
               }`}
             >
               {option === "custom" ? "Custom" : option}
@@ -90,19 +146,50 @@ export function BorderRadiusSelector({
           ))}
         </div>
         {selected === "custom" && (
-          <div className="flex items-center gap-2">
-            <div className="relative flex items-center">
+          <div className="w-36 flex items-center gap-2">
+            <div className="group relative flex items-center w-full">
               <input
+                ref={customValueInputRef}
                 type="number"
-                min="0"
+                min="1"
                 max="999"
-                value={customValue}
+                step="1"
+                value={customValue === null ? "" : customValue}
                 onChange={handleInputChange}
-                onKeyDown={handleKeyDown}
-                className="w-24 rounded-lg bg-white/5 px-3 py-1.5 text-sm text-white"
+                onBlur={handleInputBlur}
+                onKeyDown={(e) => handleCustomValueStep({ e, context: 'keyboard' })}
+                className="w-full h-10 rounded-lg px-3 pr-[50px] py-2 text-sm font-medium bg-white/5 text-white/60 group-hover:text-white group-focus-within:text-white placeholder:text-gray-500 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 focus-visible:ring-offset-none group-focus-within:ring-2 group-focus-within:ring-white/30 disabled:cursor-not-allowed disabled:opacity-50 [&::-webkit-inner-spin-button]:[-webkit-appearance:none] [&::-webkit-outer-spin-button]:[-webkit-appearance:none] [&::-webkit-inner-spin-button]:opacity-0 [&::-webkit-outer-spin-button]:opacity-0"
                 placeholder="Enter radius"
               />
-              <span className="absolute right-3 text-sm text-white/60">px</span>
+              <span className="absolute right-8 font-medium text-sm text-gray-500">px</span>
+              <button
+                ref={customValueIncrementRef}
+                className="absolute right-2 top-2 flex items-center justify-center w-4 h-3 cursor-pointer transition-colors text-gray-500 hover:text-white focus:rounded-sm focus:outline-none focus:ring-none focus:text-white focus:bg-white/10"
+                onClick={(e) => handleCustomValueStep({ e, context: 'button-up' })}
+                onMouseLeave={() => {
+                  // prevent increment/decrement buttons from retaining focus after click and even after mouseleave
+                  if (document.activeElement === customValueIncrementRef.current) {
+                    customValueIncrementRef.current?.blur();
+                    customValueInputRef.current?.focus();
+                  }
+                }}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="m18 15-6-6-6 6"/></svg>
+              </button>
+              <button
+                ref={customValueDecrementRef}
+                className="absolute right-2 bottom-2 flex items-center justify-center w-4 h-3 cursor-pointer transition-colors text-gray-500 hover:text-white focus:rounded-sm focus:outline-none focus:ring-none focus:text-white focus:bg-white/10"
+                onClick={(e) => handleCustomValueStep({ e, context: 'button-down' })}
+                onMouseLeave={() => {
+                  // prevent increment/decrement buttons from retaining focus after click and even after mouseleave
+                  if (document.activeElement === customValueDecrementRef.current) {
+                    customValueDecrementRef.current?.blur();
+                    customValueInputRef.current?.focus();
+                  }
+                }}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+              </button>
             </div>
           </div>
         )}

--- a/src/components/shared/error-message.tsx
+++ b/src/components/shared/error-message.tsx
@@ -1,0 +1,32 @@
+interface ErrorMessageProps {
+  error: string; 
+}
+
+export function ErrorMessage({ error }: ErrorMessageProps) {
+  return (
+    <p
+      id="error-message"
+      role="alert"
+      aria-live="assertive"
+      className="flex gap-2 items-center px-4 py-2 rounded-lg bg-red-500/10 text-red-500"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="size-4 shrink-0"
+      >
+        <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/>
+        <path d="M12 9v4"/>
+        <path d="M12 17h.01"/>
+      </svg>
+      {error}
+    </p>
+  );
+}

--- a/src/components/shared/error-message.tsx
+++ b/src/components/shared/error-message.tsx
@@ -1,3 +1,5 @@
+import { WarningIcon } from "@/components/shared/icons";
+
 interface ErrorMessageProps {
   error: string; 
 }
@@ -10,22 +12,7 @@ export function ErrorMessage({ error }: ErrorMessageProps) {
       aria-live="assertive"
       className="flex gap-2 items-center px-4 py-2 rounded-lg bg-red-500/10 text-red-500"
     >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="16"
-        height="16"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className="size-4 shrink-0"
-      >
-        <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/>
-        <path d="M12 9v4"/>
-        <path d="M12 17h.01"/>
-      </svg>
+      <WarningIcon />
       {error}
     </p>
   );

--- a/src/components/shared/error-message.tsx
+++ b/src/components/shared/error-message.tsx
@@ -1,8 +1,8 @@
 import { WarningIcon } from "@/components/shared/icons";
 
-interface ErrorMessageProps {
-  error: string; 
-}
+type ErrorMessageProps = {
+  error: string;
+};
 
 export function ErrorMessage({ error }: ErrorMessageProps) {
   return (
@@ -10,7 +10,7 @@ export function ErrorMessage({ error }: ErrorMessageProps) {
       id="error-message"
       role="alert"
       aria-live="assertive"
-      className="flex gap-2 items-center px-4 py-2 rounded-lg bg-red-500/10 text-red-500"
+      className="flex items-center gap-2 rounded-lg bg-red-500/10 px-4 py-2 text-red-500"
     >
       <WarningIcon />
       {error}

--- a/src/components/shared/fetch-from-url-form.tsx
+++ b/src/components/shared/fetch-from-url-form.tsx
@@ -1,3 +1,5 @@
+import { LinkIcon } from "@/components/shared/icons";
+
 function Spinner() {
   return (
     <span
@@ -34,23 +36,7 @@ export function FetchFromUrlForm({ accept, error, handleSubmit, pending }: Fetch
               'aria-describedby': 'error-message'
             })}
           />
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="absolute left-2 top-2.5 size-5 text-gray-500"
-            role="img"
-            aria-hidden="true"
-          >
-            <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
-            <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
-          </svg>
+          <LinkIcon className="absolute left-2 top-2.5 size-5 text-gray-500" />
         </div>
         <input type="hidden" name="accept" value={accept} />
         <button

--- a/src/components/shared/fetch-from-url-form.tsx
+++ b/src/components/shared/fetch-from-url-form.tsx
@@ -6,47 +6,64 @@ function Spinner() {
       role="status"
       aria-live="polite"
       aria-label="Loading…"
-      className="inline-block w-4 h-4 border-2 border-white/30 border-t-transparent rounded-full [animation:spin_1s_linear_infinite]"
+      className="inline-block h-4 w-4 rounded-full border-2 border-white/30 border-t-transparent [animation:spin_1s_linear_infinite]"
     />
-  )
+  );
 }
 
 type FetchFromUrlFormProps = {
-  accept: ".svg" | "image/svg+xml" | "image/*" | ".jpg" | ".jpeg" | ".png" | ".webp";
+  accept:
+    | ".svg"
+    | "image/svg+xml"
+    | "image/*"
+    | ".jpg"
+    | ".jpeg"
+    | ".png"
+    | ".webp";
   error: string | null;
   handleSubmit: (payload: FormData) => void;
   pending: boolean;
-}
+};
 
-export function FetchFromUrlForm({ accept, error, handleSubmit, pending }: FetchFromUrlFormProps) {
+export function FetchFromUrlForm({
+  accept,
+  error,
+  handleSubmit,
+  pending,
+}: FetchFromUrlFormProps) {
   return (
-    <div className='flex flex-col items-center gap-4 w-full sm:w-container max-w-container'>
-      <form action={handleSubmit} className="flex items-center gap-2 w-full" autoComplete="off" noValidate>
-        <div className='group relative grow min-w-0'>
+    <div className="flex w-full max-w-container flex-col items-center gap-4 sm:w-container">
+      <form
+        action={handleSubmit}
+        className="flex w-full items-center gap-2"
+        autoComplete="off"
+        noValidate
+      >
+        <div className="group relative min-w-0 grow">
           <input
             type="text"
             name="url"
             placeholder="https://"
-            className="min-w-0 w-full py-2 pr-3 pl-9 h-10 font-medium text-sm rounded-lg bg-white/5 text-gray-500 group-focus-within:text-white group-hover:text-white placeholder:text-gray-500 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 focus-visible:ring-offset-none disabled:cursor-not-allowed disabled:opacity-50"
+            className="focus-visible:ring-offset-none h-10 w-full min-w-0 rounded-lg bg-white/5 py-2 pl-9 pr-3 text-sm font-medium text-gray-500 transition-colors duration-200 placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 disabled:cursor-not-allowed disabled:opacity-50 group-focus-within:text-white group-hover:text-white"
             autoComplete="off"
             required
             {...(error && {
-              'aria-invalid': true,
-              'aria-errormessage': 'error-message',
-              'aria-describedby': 'error-message'
+              "aria-invalid": true,
+              "aria-errormessage": "error-message",
+              "aria-describedby": "error-message",
             })}
           />
           <LinkIcon className="absolute left-2 top-2.5 size-5 text-gray-500" />
         </div>
         <input type="hidden" name="accept" value={accept} />
         <button
-          type='submit'
+          type="submit"
           disabled={pending}
-          className="flex justify-center items-center gap-2 rounded-lg bg-blue-600 h-10 px-4 py-2 font-semibold text-sm text-white shadow-md whitespace-nowrap transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75 disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-white/30"
+          className="flex h-10 items-center justify-center gap-2 whitespace-nowrap rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75 disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-white/30"
         >
           {pending ? <Spinner /> : "or, use URL"}
         </button>
       </form>
     </div>
-  )
+  );
 }

--- a/src/components/shared/fetch-from-url-form.tsx
+++ b/src/components/shared/fetch-from-url-form.tsx
@@ -42,7 +42,7 @@ export function FetchFromUrlForm({ accept, error, handleSubmit, pending }: Fetch
         <button
           type='submit'
           disabled={pending}
-          className="flex justify-center items-center gap-2 rounded-lg bg-blue-600 h-10 px-4 py-2 font-semibold text-white shadow-md whitespace-nowrap transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75 disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-white/30"
+          className="flex justify-center items-center gap-2 rounded-lg bg-blue-600 h-10 px-4 py-2 font-semibold text-sm text-white shadow-md whitespace-nowrap transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75 disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-white/30"
         >
           {pending ? <Spinner /> : "or, use URL"}
         </button>

--- a/src/components/shared/fetch-from-url-form.tsx
+++ b/src/components/shared/fetch-from-url-form.tsx
@@ -1,0 +1,66 @@
+function Spinner() {
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      aria-label="Loading…"
+      className="inline-block w-4 h-4 border-2 border-white/30 border-t-transparent rounded-full [animation:spin_1s_linear_infinite]"
+    />
+  )
+}
+
+type FetchFromUrlFormProps = {
+  accept: ".svg" | "image/svg+xml" | "image/*" | ".jpg" | ".jpeg" | ".png" | ".webp";
+  error: string | null;
+  handleSubmit: (payload: FormData) => void;
+  pending: boolean;
+}
+
+export function FetchFromUrlForm({ accept, error, handleSubmit, pending }: FetchFromUrlFormProps) {
+  return (
+    <div className='flex flex-col items-center gap-4 w-full sm:w-container max-w-container'>
+      <form action={handleSubmit} className="flex items-center gap-2 w-full" autoComplete="off" noValidate>
+        <div className='group relative grow min-w-0'>
+          <input
+            type="text"
+            name="url"
+            placeholder="https://"
+            className="min-w-0 w-full py-2 pr-3 pl-9 h-10 font-medium text-sm rounded-lg bg-white/5 text-gray-500 group-focus-within:text-white group-hover:text-white placeholder:text-gray-500 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 focus-visible:ring-offset-none disabled:cursor-not-allowed disabled:opacity-50"
+            autoComplete="off"
+            required
+            {...(error && {
+              'aria-invalid': true,
+              'aria-errormessage': 'error-message',
+              'aria-describedby': 'error-message'
+            })}
+          />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="absolute left-2 top-2.5 size-5 text-gray-500"
+            role="img"
+            aria-hidden="true"
+          >
+            <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
+            <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
+          </svg>
+        </div>
+        <input type="hidden" name="accept" value={accept} />
+        <button
+          type='submit'
+          disabled={pending}
+          className="flex justify-center items-center gap-2 rounded-lg bg-blue-600 h-10 px-4 py-2 font-semibold text-white shadow-md whitespace-nowrap transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75 disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-white/30"
+        >
+          {pending ? <Spinner /> : "or, use URL"}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/components/shared/file-dropzone.tsx
+++ b/src/components/shared/file-dropzone.tsx
@@ -25,7 +25,7 @@ export function FileDropzone({
   const handleDrag = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
-  }
+  };
 
   const handleDragIn = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -35,7 +35,7 @@ export function FileDropzone({
     if (e.dataTransfer?.items && e.dataTransfer.items.length > 0) {
       setIsDragging(true);
     }
-  }
+  };
 
   const handleDragOut = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -45,7 +45,7 @@ export function FileDropzone({
     if (dragCounter.current === 0) {
       setIsDragging(false);
     }
-  }
+  };
 
   const handleDrop = useCallback(
     (e: React.DragEvent<HTMLDivElement>) => {
@@ -67,12 +67,20 @@ export function FileDropzone({
         if (
           !acceptedFileTypes.includes(droppedFile.type) &&
           !acceptedFileTypes.some((type) =>
-            droppedFile.name.toLowerCase().endsWith(type.replace("*", ""))
+            droppedFile.name.toLowerCase().endsWith(type.replace("*", "")),
           )
         ) {
-          const acceptedFileTypesString = generateFileTypesString(acceptedFileTypes as FileTypeString[]);
-          if (onError) onError(`Uploaded file has invalid type. Valid types are: ${acceptedFileTypesString}.`); 
-          else alert(`Uploaded file has invalid type. Valid types are: ${acceptedFileTypesString}.`);
+          const acceptedFileTypesString = generateFileTypesString(
+            acceptedFileTypes as FileTypeString[],
+          );
+          if (onError)
+            onError(
+              `Uploaded file has invalid type. Valid types are: ${acceptedFileTypesString}.`,
+            );
+          else
+            alert(
+              `Uploaded file has invalid type. Valid types are: ${acceptedFileTypesString}.`,
+            );
           return;
         }
 
@@ -92,9 +100,9 @@ export function FileDropzone({
       className="size-full"
     >
       {isDragging && (
-        <div className="fixed inset-0 z-50 p-8 flex items-center justify-center">
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-8">
           <div className="absolute inset-0 bg-black/80 backdrop-blur-md" />
-          <div className="animate-in fade-in zoom-in relative flex flex-col size-full transform items-center justify-center rounded-xl border-2 border-dashed border-white/30 transition-all duration-200 ease-out">
+          <div className="animate-in fade-in zoom-in relative flex size-full transform flex-col items-center justify-center rounded-xl border-2 border-dashed border-white/30 transition-all duration-200 ease-out">
             <UploadIcon className="size-12 text-gray-500" />
             <p className="text-2xl font-semibold text-gray-500">{dropText}</p>
           </div>

--- a/src/components/shared/file-dropzone.tsx
+++ b/src/components/shared/file-dropzone.tsx
@@ -20,12 +20,12 @@ export function FileDropzone({
   const [isDragging, setIsDragging] = useState(false);
   const dragCounter = useRef(0);
 
-  const handleDrag = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+  const handleDrag = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
-  }, []);
+  }
 
-  const handleDragIn = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+  const handleDragIn = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
     dragCounter.current++;
@@ -33,9 +33,9 @@ export function FileDropzone({
     if (e.dataTransfer?.items && e.dataTransfer.items.length > 0) {
       setIsDragging(true);
     }
-  }, []);
+  }
 
-  const handleDragOut = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+  const handleDragOut = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
     dragCounter.current--;
@@ -43,7 +43,7 @@ export function FileDropzone({
     if (dragCounter.current === 0) {
       setIsDragging(false);
     }
-  }, []);
+  }
 
   const handleDrop = useCallback(
     (e: React.DragEvent<HTMLDivElement>) => {
@@ -90,10 +90,28 @@ export function FileDropzone({
       className="h-full w-full"
     >
       {isDragging && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center">
-          <div className="absolute inset-0 bg-black/80 backdrop-blur-sm" />
-          <div className="animate-in fade-in zoom-in relative flex h-[90%] w-[90%] transform items-center justify-center rounded-xl border-2 border-dashed border-white/30 transition-all duration-200 ease-out">
-            <p className="text-2xl font-semibold text-white">{dropText}</p>
+        <div className="fixed inset-0 z-50 p-8 flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/80 backdrop-blur-md" />
+          <div className="animate-in fade-in zoom-in relative flex flex-col size-full transform items-center justify-center rounded-xl border-2 border-dashed border-white/30 transition-all duration-200 ease-out">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="size-12 text-gray-500"
+              role="img"
+              aria-hidden="true"
+            >
+              <path d="M12 13v8"/>
+              <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242"/>
+              <path d="m8 17 4-4 4 4"/>
+            </svg>
+            <p className="text-2xl font-semibold text-gray-500">{dropText}</p>
           </div>
         </div>
       )}

--- a/src/components/shared/file-dropzone.tsx
+++ b/src/components/shared/file-dropzone.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useState, useRef } from "react";
 
+import { UploadIcon } from "@/components/shared/icons";
+
 import { type FileTypeString, generateFileTypesString } from "@/lib/file-utils";
 
 interface FileDropzoneProps {
@@ -87,30 +89,13 @@ export function FileDropzone({
       onDragLeave={handleDragOut}
       onDragOver={handleDrag}
       onDrop={handleDrop}
-      className="h-full w-full"
+      className="size-full"
     >
       {isDragging && (
         <div className="fixed inset-0 z-50 p-8 flex items-center justify-center">
           <div className="absolute inset-0 bg-black/80 backdrop-blur-md" />
           <div className="animate-in fade-in zoom-in relative flex flex-col size-full transform items-center justify-center rounded-xl border-2 border-dashed border-white/30 transition-all duration-200 ease-out">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="size-12 text-gray-500"
-              role="img"
-              aria-hidden="true"
-            >
-              <path d="M12 13v8"/>
-              <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242"/>
-              <path d="m8 17 4-4 4 4"/>
-            </svg>
+            <UploadIcon className="size-12 text-gray-500" />
             <p className="text-2xl font-semibold text-gray-500">{dropText}</p>
           </div>
         </div>

--- a/src/components/shared/file-dropzone.tsx
+++ b/src/components/shared/file-dropzone.tsx
@@ -1,10 +1,13 @@
 import React, { useCallback, useState, useRef } from "react";
 
+import { type FileTypeString, generateFileTypesString } from "@/lib/file-utils";
+
 interface FileDropzoneProps {
   children: React.ReactNode;
   acceptedFileTypes: string[];
   dropText: string;
   setCurrentFile: (file: File) => void;
+  onError?: (error: string | null) => void;
 }
 
 export function FileDropzone({
@@ -12,6 +15,7 @@ export function FileDropzone({
   acceptedFileTypes,
   dropText,
   setCurrentFile,
+  onError,
 }: FileDropzoneProps) {
   const [isDragging, setIsDragging] = useState(false);
   const dragCounter = useRef(0);
@@ -53,25 +57,28 @@ export function FileDropzone({
         const droppedFile = files[0];
 
         if (!droppedFile) {
-          alert("How did you do a drop with no files???");
-          throw new Error("No files dropped");
+          if (onError) onError("How did you do a drop with no files???");
+          else alert("How did you do a drop with no files???");
+          return;
         }
 
         if (
           !acceptedFileTypes.includes(droppedFile.type) &&
           !acceptedFileTypes.some((type) =>
-            droppedFile.name.toLowerCase().endsWith(type.replace("*", "")),
+            droppedFile.name.toLowerCase().endsWith(type.replace("*", ""))
           )
         ) {
-          alert("Invalid file type. Please upload a supported file type.");
-          throw new Error("Invalid file");
+          const acceptedFileTypesString = generateFileTypesString(acceptedFileTypes as FileTypeString[]);
+          if (onError) onError(`Uploaded file has invalid type. Valid types are: ${acceptedFileTypesString}.`); 
+          else alert(`Uploaded file has invalid type. Valid types are: ${acceptedFileTypesString}.`);
+          return;
         }
 
         // Happy path
         setCurrentFile(droppedFile);
       }
     },
-    [acceptedFileTypes, setCurrentFile],
+    [acceptedFileTypes, setCurrentFile, onError],
   );
 
   return (

--- a/src/components/shared/footer.tsx
+++ b/src/components/shared/footer.tsx
@@ -7,7 +7,7 @@ export function Footer() {
         href="https://github.com/t3dotgg/quickpic"
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-2 px-3 py-1 text-sm font-medium hover:text-gray-200 focus:text-gray-200 transition-colors duration-200"
+        className="inline-flex items-center gap-2 px-3 py-1 text-sm font-medium transition-colors duration-200 hover:text-gray-200 focus:text-gray-200"
       >
         <GitHubIcon />
         {/* <RepositoryIcon strokeWidth={1.5} /> */}
@@ -17,5 +17,5 @@ export function Footer() {
         </span>
       </a>
     </footer>
-  )
+  );
 }

--- a/src/components/shared/footer.tsx
+++ b/src/components/shared/footer.tsx
@@ -1,0 +1,17 @@
+import { GitHubIcon } from "@/components/shared/icons";
+
+export function Footer() {
+  return (
+    <footer className="mt-8 text-center text-sm text-gray-500">
+      <a
+        href="https://github.com/t3dotgg/quickpic"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1 px-3 py-1 text-sm font-medium hover:text-gray-200 focus:text-gray-200 transition-colors duration-200"
+      >
+        <GitHubIcon />
+        View on GitHub
+      </a>
+    </footer>
+  )
+}

--- a/src/components/shared/footer.tsx
+++ b/src/components/shared/footer.tsx
@@ -1,4 +1,4 @@
-import { GitHubIcon } from "@/components/shared/icons";
+import { ArrowUpRightIcon, GitHubIcon } from "@/components/shared/icons";
 
 export function Footer() {
   return (
@@ -7,10 +7,14 @@ export function Footer() {
         href="https://github.com/t3dotgg/quickpic"
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-1 px-3 py-1 text-sm font-medium hover:text-gray-200 focus:text-gray-200 transition-colors duration-200"
+        className="inline-flex items-center gap-2 px-3 py-1 text-sm font-medium hover:text-gray-200 focus:text-gray-200 transition-colors duration-200"
       >
         <GitHubIcon />
-        View on GitHub
+        {/* <RepositoryIcon strokeWidth={1.5} /> */}
+        <span className="inline-flex items-center">
+          View on GitHub
+          <ArrowUpRightIcon />
+        </span>
       </a>
     </footer>
   )

--- a/src/components/shared/icons.tsx
+++ b/src/components/shared/icons.tsx
@@ -57,6 +57,19 @@ export function ClipboardPasteIcon({ className, strokeWidth }: IconProps) {
   );
 }
 
+export function CornerRounderIcon({ className, strokeWidth }: IconProps) {
+  return (
+    <svg
+      {...defaultProps}
+      strokeWidth={strokeWidth ?? 2}
+      className={`size-4 shrink-0 ${className}`}
+    >
+      <path d="M21 11a8 8 0 0 0-8-8" />
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+    </svg>
+  );
+}
+
 export function DownloadIcon({ className, strokeWidth }: IconProps) {
   return (
     <svg
@@ -106,6 +119,40 @@ export function LinkIcon({ className, strokeWidth }: IconProps) {
     >
       <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
       <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  );
+}
+
+export function SquareImageIcon({ className, strokeWidth }: IconProps) {
+  return (
+    <svg
+      {...defaultProps}
+      strokeWidth={strokeWidth ?? 2}
+      className={`size-4 shrink-0 ${className}`}
+    >
+      <path d="M16 3h5v5" />
+      <path d="M17 21h2a2 2 0 0 0 2-2" />
+      <path d="M21 12v3" />
+      <path d="m21 3-5 5" />
+      <path d="M3 7V5a2 2 0 0 1 2-2" />
+      <path d="m5 21 4.144-4.144a1.21 1.21 0 0 1 1.712 0L13 19" />
+      <path d="M9 3h3" />
+      <rect x="3" y="11" width="10" height="10" rx="1" />
+    </svg>
+  );
+}
+
+export function SvgToPngIcon({ className, strokeWidth }: IconProps) {
+  return (
+    <svg
+      {...defaultProps}
+      strokeWidth={strokeWidth ?? 2}
+      className={`size-4 shrink-0 ${className}`}
+    >
+      <path d="M4 16a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2" />
+      <rect width="14" height="14" x="8" y="8" rx="2" />
+      <circle cx="14" cy="14" r="2" />
+      <path d="m13.4 22 4.7-3.9c.8-.8 2-.8 2.8 0l1.1 1.1" />
     </svg>
   );
 }

--- a/src/components/shared/icons.tsx
+++ b/src/components/shared/icons.tsx
@@ -11,7 +11,7 @@ const defaultProps: React.SVGProps<SVGSVGElement> = {
   className: "size-4 shrink-0",
   role: "img",
   "aria-hidden": "true",
-}
+};
 
 interface IconProps extends React.SVGProps<SVGSVGElement> {
   className?: string;
@@ -37,8 +37,8 @@ export function ArrowUpRightIcon({ className, strokeWidth }: IconProps) {
       strokeWidth={strokeWidth ?? 2}
       className={`size-4 shrink-0 ${className}`}
     >
-      <path d="M7 7h10v10"/>
-      <path d="M7 17 17 7"/>
+      <path d="M7 7h10v10" />
+      <path d="M7 17 17 7" />
     </svg>
   );
 }
@@ -50,9 +50,9 @@ export function ClipboardPasteIcon({ className, strokeWidth }: IconProps) {
       strokeWidth={strokeWidth ?? 2}
       className={`size-4 shrink-0 ${className}`}
     >
-      <path d="M15 2H9a1 1 0 0 0-1 1v2c0 .6.4 1 1 1h6c.6 0 1-.4 1-1V3c0-.6-.4-1-1-1Z"/>
-      <path d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2M16 4h2a2 2 0 0 1 2 2v2M11 14h10"/>
-      <path d="m17 10 4 4-4 4"/>
+      <path d="M15 2H9a1 1 0 0 0-1 1v2c0 .6.4 1 1 1h6c.6 0 1-.4 1-1V3c0-.6-.4-1-1-1Z" />
+      <path d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2M16 4h2a2 2 0 0 1 2 2v2M11 14h10" />
+      <path d="m17 10 4 4-4 4" />
     </svg>
   );
 }
@@ -63,10 +63,10 @@ export function DownloadIcon({ className, strokeWidth }: IconProps) {
       {...defaultProps}
       strokeWidth={strokeWidth ?? 2}
       className={`size-4 shrink-0 ${className}`}
-     >
-      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-      <polyline points="7 10 12 15 17 10"/>
-      <line x1="12" x2="12" y1="15" y2="3"/>
+    >
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" x2="12" y1="15" y2="3" />
     </svg>
   );
 }
@@ -78,8 +78,8 @@ export function EyeIcon({ className, strokeWidth }: IconProps) {
       strokeWidth={strokeWidth ?? 2}
       className={`size-4 shrink-0 ${className}`}
     >
-      <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/>
-      <circle cx="12" cy="12" r="3"/>
+      <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0" />
+      <circle cx="12" cy="12" r="3" />
     </svg>
   );
 }
@@ -91,9 +91,9 @@ export function GitHubIcon({ className, strokeWidth }: IconProps) {
       strokeWidth={strokeWidth ?? 2}
       className={`size-4 shrink-0 ${className}`}
     >
-      <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/>
-      <path d="M9 18c-4.51 2-5-2-7-2"/>
-    </svg>   
+      <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
+      <path d="M9 18c-4.51 2-5-2-7-2" />
+    </svg>
   );
 }
 
@@ -104,8 +104,8 @@ export function LinkIcon({ className, strokeWidth }: IconProps) {
       strokeWidth={strokeWidth ?? 2}
       className={`size-4 shrink-0 ${className}`}
     >
-      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
-      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
     </svg>
   );
 }
@@ -117,9 +117,9 @@ export function UploadIcon({ className, strokeWidth }: IconProps) {
       strokeWidth={strokeWidth ?? 2}
       className={`size-4 shrink-0 ${className}`}
     >
-      <path d="M12 13v8"/>
-      <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242"/>
-      <path d="m8 17 4-4 4 4"/>
+      <path d="M12 13v8" />
+      <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242" />
+      <path d="m8 17 4-4 4 4" />
     </svg>
   );
 }
@@ -131,9 +131,9 @@ export function WarningIcon({ className, strokeWidth }: IconProps) {
       strokeWidth={strokeWidth ?? 2}
       className={`size-4 shrink-0 ${className}`}
     >
-      <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/>
-      <path d="M12 9v4"/>
-      <path d="M12 17h.01"/>
+      <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3" />
+      <path d="M12 9v4" />
+      <path d="M12 17h.01" />
     </svg>
   );
 }

--- a/src/components/shared/icons.tsx
+++ b/src/components/shared/icons.tsx
@@ -1,0 +1,126 @@
+const defaultProps: React.SVGProps<SVGSVGElement> = {
+  xmlns: "http://www.w3.org/2000/svg",
+  width: "24",
+  height: "24",
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: "2",
+  strokeLinecap: "round",
+  strokeLinejoin: "round",
+  className: "size-4 shrink-0",
+  role: "img",
+  "aria-hidden": "true",
+}
+
+interface IconProps extends React.SVGProps<SVGSVGElement> {
+  className?: string;
+  strokeWidth?: number;
+}
+
+export function ArrowLeftIcon({ className, strokeWidth }: IconProps) {
+  return (
+    <svg
+      {...defaultProps}
+      strokeWidth={strokeWidth ?? 2}
+      className={`size-4 shrink-0 ${className}`}
+    >
+      <path d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+    </svg>
+  );
+}
+
+export function ClipboardPasteIcon({ className, strokeWidth }: IconProps) {
+  return (
+    <svg
+      {...defaultProps}
+      strokeWidth={strokeWidth ?? 2}
+      className={`size-4 shrink-0 ${className}`}
+    >
+      <path d="M15 2H9a1 1 0 0 0-1 1v2c0 .6.4 1 1 1h6c.6 0 1-.4 1-1V3c0-.6-.4-1-1-1Z"/>
+      <path d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2M16 4h2a2 2 0 0 1 2 2v2M11 14h10"/>
+      <path d="m17 10 4 4-4 4"/>
+    </svg>
+  );
+}
+
+export function DownloadIcon({ className, strokeWidth }: IconProps) {
+  return (
+    <svg
+      {...defaultProps}
+      strokeWidth={strokeWidth ?? 2}
+      className={`size-4 shrink-0 ${className}`}
+     >
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+      <polyline points="7 10 12 15 17 10"/>
+      <line x1="12" x2="12" y1="15" y2="3"/>
+    </svg>
+  );
+}
+
+export function EyeIcon({ className, strokeWidth }: IconProps) {
+  return (
+    <svg
+      {...defaultProps}
+      strokeWidth={strokeWidth ?? 2}
+      className={`size-4 shrink-0 ${className}`}
+    >
+      <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/>
+      <circle cx="12" cy="12" r="3"/>
+    </svg>
+  );
+}
+
+export function GitHubIcon({ className, strokeWidth }: IconProps) {
+  return (
+    <svg
+      {...defaultProps}
+      strokeWidth={strokeWidth ?? 2}
+      className={`size-4 shrink-0 ${className}`}
+    >
+      <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/>
+      <path d="M9 18c-4.51 2-5-2-7-2"/>
+    </svg>   
+  );
+}
+
+export function LinkIcon({ className, strokeWidth }: IconProps) {
+  return (
+    <svg
+      {...defaultProps}
+      strokeWidth={strokeWidth ?? 2}
+      className={`size-4 shrink-0 ${className}`}
+    >
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
+    </svg>
+  );
+}
+
+export function UploadIcon({ className, strokeWidth }: IconProps) {
+  return (
+    <svg
+      {...defaultProps}
+      strokeWidth={strokeWidth ?? 2}
+      className={`size-4 shrink-0 ${className}`}
+    >
+      <path d="M12 13v8"/>
+      <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242"/>
+      <path d="m8 17 4-4 4 4"/>
+    </svg>
+  );
+}
+
+export function WarningIcon({ className, strokeWidth }: IconProps) {
+  return (
+    <svg
+      {...defaultProps}
+      strokeWidth={strokeWidth ?? 2}
+      className={`size-4 shrink-0 ${className}`}
+    >
+      <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/>
+      <path d="M12 9v4"/>
+      <path d="M12 17h.01"/>
+    </svg>
+  );
+}

--- a/src/components/shared/icons.tsx
+++ b/src/components/shared/icons.tsx
@@ -30,6 +30,19 @@ export function ArrowLeftIcon({ className, strokeWidth }: IconProps) {
   );
 }
 
+export function ArrowUpRightIcon({ className, strokeWidth }: IconProps) {
+  return (
+    <svg
+      {...defaultProps}
+      strokeWidth={strokeWidth ?? 2}
+      className={`size-4 shrink-0 ${className}`}
+    >
+      <path d="M7 7h10v10"/>
+      <path d="M7 17 17 7"/>
+    </svg>
+  );
+}
+
 export function ClipboardPasteIcon({ className, strokeWidth }: IconProps) {
   return (
     <svg

--- a/src/components/shared/option-selector.tsx
+++ b/src/components/shared/option-selector.tsx
@@ -22,23 +22,26 @@ export function OptionSelector<T extends string | number>({
   const highlightRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (selectedRef.current && highlightRef.current && containerRef.current) {
-      const container = containerRef.current;
-      const selected = selectedRef.current;
-      const highlight = highlightRef.current;
+    if (!selectedRef.current || !highlightRef.current || !containerRef.current) return;
+
+    // prevent layout thrashing
+    requestAnimationFrame(() => {
+      const container = containerRef.current!;
+      const selected = selectedRef.current!;
+      const highlight = highlightRef.current!;
 
       const containerRect = container.getBoundingClientRect();
       const selectedRect = selected.getBoundingClientRect();
 
       highlight.style.left = `${selectedRect.left - containerRect.left}px`;
       highlight.style.width = `${selectedRect.width}px`;
-    }
+    });
   }, [selected]);
 
   return (
     <div className="flex flex-col items-center gap-2">
       <span className="text-sm text-white/60">{title}</span>
-      <div className="flex flex-col items-center gap-2">
+      <div className="flex flex-col items-center justify-center gap-2">
         <div
           ref={containerRef}
           className="relative inline-flex rounded-lg bg-white/5 p-1"
@@ -52,10 +55,10 @@ export function OptionSelector<T extends string | number>({
               key={option}
               ref={option === selected ? selectedRef : null}
               onClick={() => onChange(option)}
-              className={`relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+              className={`option relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-none ${
                 option === selected
                   ? "text-white"
-                  : "text-white/80 hover:text-white"
+                  : "text-white/60 hover:text-white focus:bg-white/10"
               }`}
             >
               {formatOption(option)}

--- a/src/components/shared/option-selector.tsx
+++ b/src/components/shared/option-selector.tsx
@@ -29,7 +29,8 @@ export function OptionSelector<T extends string | number>({
   const highlightRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!selectedRef.current || !highlightRef.current || !containerRef.current) return;
+    if (!selectedRef.current || !highlightRef.current || !containerRef.current)
+      return;
 
     // prevent layout thrashing
     requestAnimationFrame(() => {
@@ -44,16 +45,20 @@ export function OptionSelector<T extends string | number>({
       highlight.style.width = `${selectedRect.width}px`;
     });
 
-  // though isXsScreen is not a real dependency, the selected scale option must
-  // be re-rerendered when it changes, because otherwise the highlight will be
-  // missing/not calculated when the user resizes the window and the scale selector
-  // switches between its two different display modes
+    // though isXsScreen is not a real dependency, the selected scale option must
+    // be re-rerendered when it changes, because otherwise the highlight will be
+    // missing/not calculated when the user resizes the window and the scale selector
+    // switches between its two different display modes
   }, [selected, isXsScreen]);
 
   return (
-    <div className={`${isXsScreen ? "w-full" : ""} flex flex-col items-center gap-2`}>
+    <div
+      className={`${isXsScreen ? "w-full" : ""} flex flex-col items-center gap-2`}
+    >
       <span className="text-sm text-white/60">{title}</span>
-      <div className={`flex ${isXsScreen ? "flex-row w-full" : "flex-col"} items-center justify-center gap-2`}>
+      <div
+        className={`flex ${isXsScreen ? "w-full flex-row" : "flex-col"} items-center justify-center gap-2`}
+      >
         {isXsScreen ? (
           <Select
             options={options}
@@ -76,7 +81,7 @@ export function OptionSelector<T extends string | number>({
                 key={option}
                 ref={option === selected ? selectedRef : null}
                 onClick={() => onChange(option)}
-                className={`option relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-none ${
+                className={`option focus:ring-none relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none ${
                   option === selected
                     ? "text-white"
                     : "text-white/60 hover:text-white focus:bg-white/10"

--- a/src/components/shared/option-selector.tsx
+++ b/src/components/shared/option-selector.tsx
@@ -2,21 +2,28 @@
 
 import { useEffect, useRef } from "react";
 
+import { Select } from "@/components/shared/select";
+
+import { useMediaQuery } from "@/hooks/use-media-query";
+
 interface OptionSelectorProps<T extends string | number> {
-  title: string;
+  className?: string;
+  formatOption?: (option: T) => string;
+  onChange: (value: T) => void;
   options: T[];
   selected: T;
-  onChange: (value: T) => void;
-  formatOption?: (option: T) => string;
+  title: string;
 }
 
 export function OptionSelector<T extends string | number>({
-  title,
+  className,
+  formatOption = (option) => `${option}`,
+  onChange,
   options,
   selected,
-  onChange,
-  formatOption = (option) => `${option}`,
+  title,
 }: OptionSelectorProps<T>) {
+  const isXsScreen = useMediaQuery("(max-width: 29rem)");
   const containerRef = useRef<HTMLDivElement>(null);
   const selectedRef = useRef<HTMLButtonElement>(null);
   const highlightRef = useRef<HTMLDivElement>(null);
@@ -36,35 +43,50 @@ export function OptionSelector<T extends string | number>({
       highlight.style.left = `${selectedRect.left - containerRect.left}px`;
       highlight.style.width = `${selectedRect.width}px`;
     });
-  }, [selected]);
+
+  // though isXsScreen is not a real dependency, the selected scale option must
+  // be re-rerendered when it changes, because otherwise the highlight will be
+  // missing/not calculated when the user resizes the window and the scale selector
+  // switches between its two different display modes
+  }, [selected, isXsScreen]);
 
   return (
-    <div className="flex flex-col items-center gap-2">
+    <div className={`${isXsScreen ? "w-full" : ""} flex flex-col items-center gap-2`}>
       <span className="text-sm text-white/60">{title}</span>
-      <div className="flex flex-col items-center justify-center gap-2">
-        <div
-          ref={containerRef}
-          className="relative inline-flex rounded-lg bg-white/5 p-1"
-        >
-          <div
-            ref={highlightRef}
-            className="absolute top-1 h-[calc(100%-8px)] rounded-md bg-blue-600 transition-all duration-200"
+      <div className={`flex ${isXsScreen ? "flex-row w-full" : "flex-col"} items-center justify-center gap-2`}>
+        {isXsScreen ? (
+          <Select
+            options={options}
+            selected={selected}
+            onChange={onChange}
+            formatOption={formatOption}
+            className={className}
           />
-          {options.map((option) => (
-            <button
-              key={option}
-              ref={option === selected ? selectedRef : null}
-              onClick={() => onChange(option)}
-              className={`option relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-none ${
-                option === selected
-                  ? "text-white"
-                  : "text-white/60 hover:text-white focus:bg-white/10"
-              }`}
-            >
-              {formatOption(option)}
-            </button>
-          ))}
-        </div>
+        ) : (
+          <div
+            ref={containerRef}
+            className="relative inline-flex rounded-lg bg-white/5 p-1"
+          >
+            <div
+              ref={highlightRef}
+              className="absolute top-1 h-[calc(100%-8px)] rounded-md bg-blue-600 transition-all duration-200"
+            />
+            {options.map((option) => (
+              <button
+                key={option}
+                ref={option === selected ? selectedRef : null}
+                onClick={() => onChange(option)}
+                className={`option relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-none ${
+                  option === selected
+                    ? "text-white"
+                    : "text-white/60 hover:text-white focus:bg-white/10"
+                }`}
+              >
+                {formatOption(option)}
+              </button>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/shared/page-title.tsx
+++ b/src/components/shared/page-title.tsx
@@ -1,4 +1,8 @@
 export function PageTitle({ title }: { title: string }) {
   const text = title.split(" - ")[0];
-  return <div className="fixed left-1/2 -translate-x-1/2 top-4 z-40 px-10 2xs:px-3 py-1 text-sm font-medium text-gray-500 text-center">{text}</div>
+  return (
+    <div className="fixed left-1/2 top-4 z-40 -translate-x-1/2 px-10 py-1 text-center text-sm font-medium text-gray-500 2xs:px-3">
+      {text}
+    </div>
+  );
 }

--- a/src/components/shared/page-title.tsx
+++ b/src/components/shared/page-title.tsx
@@ -1,0 +1,4 @@
+export function PageTitle({ title }: { title: string }) {
+  const text = title.split(" - ")[0];
+  return <div className="fixed left-1/2 -translate-x-1/2 top-4 z-40 px-10 2xs:px-3 py-1 text-sm font-medium text-gray-500 text-center">{text}</div>
+}

--- a/src/components/shared/preview-scale.tsx
+++ b/src/components/shared/preview-scale.tsx
@@ -1,24 +1,6 @@
-import { formatNumber } from "@/lib/math-utils";
+import { EyeIcon } from "@/components/shared/icons";
 
-function PreviewScaleIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="size-4 -ml-1 shrink-0"
-    >
-      <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/>
-      <circle cx="12" cy="12" r="3"/>
-    </svg>
-  )
-}
+import { formatNumber } from "@/lib/math-utils";
 
 interface PreviewScaleProps {
   previewScale: number | null;
@@ -28,7 +10,7 @@ export function PreviewScale({ previewScale }: PreviewScaleProps) {
   // If the image preview is scaled down to fit, display the scaled percentage
   return previewScale && previewScale < 1 && (
       <div className="flex items-center gap-1 rounded-full border border-white/30 bg-white/5 px-3 py-0.5 text-center text-sm text-white/60 whitespace-nowrap">
-        <PreviewScaleIcon />
+        <EyeIcon className="-ml-1" />
         {`Viewing at ${formatNumber((previewScale * 100))}%`}
       </div>
     )

--- a/src/components/shared/preview-scale.tsx
+++ b/src/components/shared/preview-scale.tsx
@@ -1,0 +1,35 @@
+import { formatNumber } from "@/lib/math-utils";
+
+function PreviewScaleIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="size-4 -ml-1 shrink-0"
+    >
+      <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/>
+      <circle cx="12" cy="12" r="3"/>
+    </svg>
+  )
+}
+
+interface PreviewScaleProps {
+  previewScale: number | null;
+}
+
+export function PreviewScale({ previewScale }: PreviewScaleProps) {
+  // If the image preview is scaled down to fit, display the scaled percentage
+  return previewScale && previewScale < 1 && (
+      <div className="flex items-center gap-1 rounded-full border border-white/30 bg-white/5 px-3 py-0.5 text-center text-sm text-white/60 whitespace-nowrap">
+        <PreviewScaleIcon />
+        {`Viewing at ${formatNumber((previewScale * 100))}%`}
+      </div>
+    )
+}

--- a/src/components/shared/preview-scale.tsx
+++ b/src/components/shared/preview-scale.tsx
@@ -2,16 +2,19 @@ import { EyeIcon } from "@/components/shared/icons";
 
 import { formatNumber } from "@/lib/math-utils";
 
-interface PreviewScaleProps {
+type PreviewScaleProps = {
   previewScale: number | null;
-}
+};
 
 export function PreviewScale({ previewScale }: PreviewScaleProps) {
   // If the image preview is scaled down to fit, display the scaled percentage
-  return previewScale && previewScale < 1 && (
-      <div className="flex items-center gap-1 rounded-full border border-white/30 bg-white/5 px-3 py-0.5 text-center text-sm text-white/60 whitespace-nowrap">
+  return (
+    previewScale &&
+    previewScale < 1 && (
+      <div className="flex items-center gap-1 whitespace-nowrap rounded-full border border-white/30 bg-white/5 px-3 py-0.5 text-center text-sm text-white/60">
         <EyeIcon className="-ml-1" />
-        {`Viewing at ${formatNumber((previewScale * 100))}%`}
+        {`Viewing at ${formatNumber(previewScale * 100)}%`}
       </div>
     )
+  );
 }

--- a/src/components/shared/select.tsx
+++ b/src/components/shared/select.tsx
@@ -1,0 +1,160 @@
+import React, { useEffect, useRef, useState } from "react";
+
+import { useKeyDown } from "@/hooks/use-keydown";
+
+interface SelectProps<T extends string | number> {
+  placeholder?: string;
+  options: T[];
+  selected: T;
+  onChange: (value: T) => void;
+  formatOption?: (option: T) => string;
+  className?: string;
+}
+
+export function Select<T extends string | number>({
+  placeholder,
+  options,
+  selected,
+  onChange,
+  formatOption = (option) => `${option}`,
+  className,
+}: SelectProps<T>) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState<number | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const selectRef = useRef<HTMLDivElement>(null);
+
+  const selectedOption = options.find((option) => option === selected);
+  const selectedLabel = selectedOption ? formatOption(selectedOption) : (placeholder ?? 'Select…');
+  const selectedIndex = options.findIndex((option) => option === selected);
+
+  const toggleOptions = () => {
+    setIsOpen((prev) => {
+      const newState = !prev;
+      if (newState) setHighlightedIndex(selectedIndex !== -1 ? selectedIndex : 0);
+      return newState;
+    });
+  }
+
+  const selectOption = (index: number) => {
+    const option = options[index];
+    
+    if (option) {
+      onChange(option);
+      setIsOpen(false);
+    }
+  };
+
+  useKeyDown(["ArrowDown", "ArrowUp"], () => {
+    setIsOpen(true);
+    setHighlightedIndex(selectedIndex !== -1 ? selectedIndex : 0); 
+  }, {
+    condition: !isOpen,
+    preventDefault: true,
+    ...(containerRef.current && { target: containerRef.current })
+  });
+
+  useKeyDown("ArrowDown", () => {
+    setIsOpen(true);
+
+    setHighlightedIndex((prevIndex) => {
+      if (prevIndex === null) return 0;
+      return (++prevIndex + options.length) % options.length;
+    });
+  }, {
+    condition: isOpen,
+    preventDefault: true,
+    ...(containerRef.current && { target: containerRef.current })
+  });
+
+  useKeyDown("ArrowUp", () => {
+    setIsOpen(true);
+
+    setHighlightedIndex((prevIndex) => {
+      if (prevIndex === null) return options.length - 1;
+      return (--prevIndex + options.length) % options.length;
+    });
+  }, {
+    condition: isOpen,
+    preventDefault: true,
+    ...(containerRef.current && { target: containerRef.current })
+  });
+
+  useKeyDown(["Enter", "Space"], () => {
+    selectOption(highlightedIndex!);
+  }, {
+    condition: isOpen && highlightedIndex !== null,
+    preventDefault: true,
+    ...(containerRef.current && { target: containerRef.current })
+  });
+
+  useKeyDown(["Enter", "Space"], () => {
+    setIsOpen(true);
+    setHighlightedIndex(selectedIndex !== -1 ? selectedIndex : 0);
+  }, {
+    condition: !isOpen || highlightedIndex === null,
+    preventDefault: true,
+    ...(containerRef.current && { target: containerRef.current })
+  });
+
+  useKeyDown("Escape", () => { setIsOpen(false); }, {
+    ...(containerRef.current && { target: containerRef.current })
+  });
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <div className={`group relative ${className}`} ref={containerRef}>
+      <div
+        ref={selectRef}
+        tabIndex={0}
+        role="combobox"
+        aria-expanded={isOpen}
+        aria-controls="select-options"
+        className="select flex items-center relative w-full h-10 rounded-lg px-3 pr-8 py-2 truncate font-medium text-sm transition-colors duration-200 bg-white/5 text-white/60 hover:text-white placeholder:text-gray-500 cursor-pointer focus:outline-none focus:ring-2 focus:ring-white/30"
+        onClick={toggleOptions}
+      >
+        <span className="truncate min-w-0 w-full overflow-hidden whitespace-nowrap">{selectedLabel}</span>
+      </div>
+
+      <span className="absolute right-2 top-1/2 transform -translate-y-1/2 text-gray-500 group-hover:text-white pointer-events-none transition-colors duration-200">
+        <svg xmlns="http://www.w3.org/2000/svg" width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+          <path d="m6 9 6 6 6-6"/>
+        </svg>
+      </span>
+
+      {isOpen && (
+        <ul
+          id="select-options"
+          role="listbox"
+          className="absolute w-full z-50 mt-2 p-1 flex flex-col gap-1 ring-2 ring-white/30 rounded-lg backdrop-blur-sm bg-[#191919] text-white overflow-hidden"
+        >
+          {options.map((option, index) => (
+            <li
+              key={option}
+              role="option"
+              aria-selected={selected === option}
+              className={`px-3 py-2 cursor-pointer text-sm font-medium rounded-md transition-colors ${
+                highlightedIndex === index ? "bg-white/10 text-white" :  "text-white/60 hover:text-white hover:bg-white/10"
+              } ${
+                selectedIndex === index ? "!bg-blue-600 hover:!bg-blue-700 focus:!bg-blue-700 !text-white" : ""}`}
+              onClick={() => selectOption(index)}
+              onMouseEnter={() => setHighlightedIndex(index)}
+            >
+              {formatOption(option)}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/shared/select.tsx
+++ b/src/components/shared/select.tsx
@@ -2,14 +2,14 @@ import React, { useEffect, useRef, useState } from "react";
 
 import { useKeyDown } from "@/hooks/use-keydown";
 
-interface SelectProps<T extends string | number> {
+type SelectProps<T extends string | number> = {
   placeholder?: string;
   options: T[];
   selected: T;
   onChange: (value: T) => void;
   formatOption?: (option: T) => string;
   className?: string;
-}
+};
 
 export function Select<T extends string | number>({
   placeholder,
@@ -25,85 +25,117 @@ export function Select<T extends string | number>({
   const selectRef = useRef<HTMLDivElement>(null);
 
   const selectedOption = options.find((option) => option === selected);
-  const selectedLabel = selectedOption ? formatOption(selectedOption) : (placeholder ?? 'Select…');
+  const selectedLabel = selectedOption
+    ? formatOption(selectedOption)
+    : (placeholder ?? "Select…");
   const selectedIndex = options.findIndex((option) => option === selected);
 
   const toggleOptions = () => {
     setIsOpen((prev) => {
       const newState = !prev;
-      if (newState) setHighlightedIndex(selectedIndex !== -1 ? selectedIndex : 0);
+      if (newState)
+        setHighlightedIndex(selectedIndex !== -1 ? selectedIndex : 0);
       return newState;
     });
-  }
+  };
 
   const selectOption = (index: number) => {
     const option = options[index];
-    
+
     if (option) {
       onChange(option);
       setIsOpen(false);
     }
   };
 
-  useKeyDown(["ArrowDown", "ArrowUp"], () => {
-    setIsOpen(true);
-    setHighlightedIndex(selectedIndex !== -1 ? selectedIndex : 0); 
-  }, {
-    condition: !isOpen,
-    preventDefault: true,
-    ...(containerRef.current && { target: containerRef.current })
-  });
+  useKeyDown(
+    ["ArrowDown", "ArrowUp"],
+    () => {
+      setIsOpen(true);
+      setHighlightedIndex(selectedIndex !== -1 ? selectedIndex : 0);
+    },
+    {
+      condition: !isOpen,
+      preventDefault: true,
+      ...(containerRef.current && { target: containerRef.current }),
+    },
+  );
 
-  useKeyDown("ArrowDown", () => {
-    setIsOpen(true);
+  useKeyDown(
+    "ArrowDown",
+    () => {
+      setIsOpen(true);
 
-    setHighlightedIndex((prevIndex) => {
-      if (prevIndex === null) return 0;
-      return (++prevIndex + options.length) % options.length;
-    });
-  }, {
-    condition: isOpen,
-    preventDefault: true,
-    ...(containerRef.current && { target: containerRef.current })
-  });
+      setHighlightedIndex((prevIndex) => {
+        if (prevIndex === null) return 0;
+        return (++prevIndex + options.length) % options.length;
+      });
+    },
+    {
+      condition: isOpen,
+      preventDefault: true,
+      ...(containerRef.current && { target: containerRef.current }),
+    },
+  );
 
-  useKeyDown("ArrowUp", () => {
-    setIsOpen(true);
+  useKeyDown(
+    "ArrowUp",
+    () => {
+      setIsOpen(true);
 
-    setHighlightedIndex((prevIndex) => {
-      if (prevIndex === null) return options.length - 1;
-      return (--prevIndex + options.length) % options.length;
-    });
-  }, {
-    condition: isOpen,
-    preventDefault: true,
-    ...(containerRef.current && { target: containerRef.current })
-  });
+      setHighlightedIndex((prevIndex) => {
+        if (prevIndex === null) return options.length - 1;
+        return (--prevIndex + options.length) % options.length;
+      });
+    },
+    {
+      condition: isOpen,
+      preventDefault: true,
+      ...(containerRef.current && { target: containerRef.current }),
+    },
+  );
 
-  useKeyDown(["Enter", "Space"], () => {
-    selectOption(highlightedIndex!);
-  }, {
-    condition: isOpen && highlightedIndex !== null,
-    preventDefault: true,
-    ...(containerRef.current && { target: containerRef.current })
-  });
+  useKeyDown(
+    ["Enter", "Space"],
+    () => {
+      selectOption(highlightedIndex!);
+    },
+    {
+      condition: isOpen && highlightedIndex !== null,
+      preventDefault: true,
+      ...(containerRef.current && { target: containerRef.current }),
+    },
+  );
 
-  useKeyDown(["Enter", "Space"], () => {
-    setIsOpen(true);
-    setHighlightedIndex(selectedIndex !== -1 ? selectedIndex : 0);
-  }, {
-    condition: !isOpen || highlightedIndex === null,
-    preventDefault: true,
-    ...(containerRef.current && { target: containerRef.current })
-  });
+  useKeyDown(
+    ["Enter", "Space"],
+    () => {
+      setIsOpen(true);
+      setHighlightedIndex(selectedIndex !== -1 ? selectedIndex : 0);
+    },
+    {
+      condition: !isOpen || highlightedIndex === null,
+      preventDefault: true,
+      ...(containerRef.current && { target: containerRef.current }),
+    },
+  );
 
-  useKeyDown("Escape", () => { setIsOpen(false); }, {
-    ...(containerRef.current && { target: containerRef.current })
-  });
+  useKeyDown(
+    "Escape",
+    () => {
+      setIsOpen(false);
+    },
+    {
+      ...(containerRef.current && { target: containerRef.current }),
+    },
+  );
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
         setIsOpen(false);
       }
     };
@@ -120,15 +152,27 @@ export function Select<T extends string | number>({
         role="combobox"
         aria-expanded={isOpen}
         aria-controls="select-options"
-        className="select flex items-center relative w-full h-10 rounded-lg px-3 pr-8 py-2 truncate font-medium text-sm transition-colors duration-200 bg-white/5 text-white/60 hover:text-white placeholder:text-gray-500 cursor-pointer focus:outline-none focus:ring-2 focus:ring-white/30"
+        className="select relative flex h-10 w-full cursor-pointer items-center truncate rounded-lg bg-white/5 px-3 py-2 pr-8 text-sm font-medium text-white/60 transition-colors duration-200 placeholder:text-gray-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-white/30"
         onClick={toggleOptions}
       >
-        <span className="truncate min-w-0 w-full overflow-hidden whitespace-nowrap">{selectedLabel}</span>
+        <span className="w-full min-w-0 overflow-hidden truncate whitespace-nowrap">
+          {selectedLabel}
+        </span>
       </div>
 
-      <span className="absolute right-2 top-1/2 transform -translate-y-1/2 text-gray-500 group-hover:text-white pointer-events-none transition-colors duration-200">
-        <svg xmlns="http://www.w3.org/2000/svg" width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
-          <path d="m6 9 6 6 6-6"/>
+      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 transform text-gray-500 transition-colors duration-200 group-hover:text-white">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={16}
+          height={16}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="m6 9 6 6 6-6" />
         </svg>
       </span>
 
@@ -136,17 +180,22 @@ export function Select<T extends string | number>({
         <ul
           id="select-options"
           role="listbox"
-          className="absolute w-full z-50 mt-2 p-1 flex flex-col gap-1 ring-2 ring-white/30 rounded-lg backdrop-blur-sm bg-[#191919] text-white overflow-hidden"
+          className="absolute z-50 mt-2 flex w-full flex-col gap-1 overflow-hidden rounded-lg bg-[#191919] p-1 text-white ring-2 ring-white/30 backdrop-blur-sm"
         >
           {options.map((option, index) => (
             <li
               key={option}
               role="option"
               aria-selected={selected === option}
-              className={`px-3 py-2 cursor-pointer text-sm font-medium rounded-md transition-colors ${
-                highlightedIndex === index ? "bg-white/10 text-white" :  "text-white/60 hover:text-white hover:bg-white/10"
+              className={`cursor-pointer rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                highlightedIndex === index
+                  ? "bg-white/10 text-white"
+                  : "text-white/60 hover:bg-white/10 hover:text-white"
               } ${
-                selectedIndex === index ? "!bg-blue-600 hover:!bg-blue-700 focus:!bg-blue-700 !text-white" : ""}`}
+                selectedIndex === index
+                  ? "!bg-blue-600 !text-white hover:!bg-blue-700 focus:!bg-blue-700"
+                  : ""
+              }`}
               onClick={() => selectOption(index)}
               onMouseEnter={() => setHighlightedIndex(index)}
             >

--- a/src/components/shared/upload-box.tsx
+++ b/src/components/shared/upload-box.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 
+import { UploadIcon } from "@/components/shared/icons";
+
 interface UploadBoxProps {
   title: string;
   subtitle?: string;
-  subtitleIcon?: React.ElementType;
+  subtitleIcon?: React.ReactElement;
   description: string;
   accept: string;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -12,7 +14,7 @@ interface UploadBoxProps {
 export function UploadBox({
   title,
   subtitle,
-  subtitleIcon: SubtitleIcon,
+  subtitleIcon,
   description,
   accept,
   onChange,
@@ -23,7 +25,7 @@ export function UploadBox({
         <p id="upload-box-title" className="text-center text-white">{title}</p>
         {subtitle && (
           <p id="upload-box-subtitle" className="flex gap-1 items-center rounded-full border border-white/30 bg-white/5 px-3 py-0.5 text-center text-sm text-white/60">
-            {SubtitleIcon && <SubtitleIcon />}
+            {subtitleIcon}
             {subtitle}
           </p>
         )}
@@ -34,24 +36,7 @@ export function UploadBox({
         aria-describedby="upload-box-instructions"
         className="flex flex-col items-center justify-center gap-4 w-full sm:w-container max-w-container rounded-xl border-2 border-dashed border-white/30 bg-white/5 p-6 backdrop-blur-sm"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="size-8 text-gray-500"
-          role="img"
-          aria-hidden="true"
-        >
-          <path d="M12 13v8"/>
-          <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242"/>
-          <path d="m8 17 4-4 4 4"/>
-        </svg>
+        <UploadIcon className="size-8 text-gray-500" />
         <p className="font-medium text-sm text-gray-500">Drag and Drop</p>
         <p className="font-medium text-sm text-gray-500">or</p>
         <label

--- a/src/components/shared/upload-box.tsx
+++ b/src/components/shared/upload-box.tsx
@@ -32,17 +32,22 @@ export function UploadBox({
         className="flex flex-col items-center justify-center gap-4 w-full sm:w-container max-w-container rounded-xl border-2 border-dashed border-white/30 bg-white/5 p-6 backdrop-blur-sm"
       >
         <svg
-          className="h-8 w-8 text-gray-400"
-          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
           viewBox="0 0 24 24"
+          fill="none"
           stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="size-8 text-gray-500"
+          role="img"
+          aria-hidden="true"
         >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
-          />
+          <path d="M12 13v8"/>
+          <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242"/>
+          <path d="m8 17 4-4 4 4"/>
         </svg>
         <p className="font-medium text-sm text-gray-500">Drag and Drop</p>
         <p className="font-medium text-sm text-gray-500">or</p>

--- a/src/components/shared/upload-box.tsx
+++ b/src/components/shared/upload-box.tsx
@@ -20,11 +20,16 @@ export function UploadBox({
   onChange,
 }: UploadBoxProps) {
   return (
-    <div className="flex flex-col items-center justify-center gap-4 w-full">
+    <div className="flex w-full flex-col items-center justify-center gap-4">
       <div className="flex flex-col items-center gap-2">
-        <p id="upload-box-title" className="text-center text-white">{title}</p>
+        <p id="upload-box-title" className="text-center text-white">
+          {title}
+        </p>
         {subtitle && (
-          <p id="upload-box-subtitle" className="flex gap-1 items-center rounded-full border border-white/30 bg-white/5 px-3 py-0.5 text-center text-sm text-white/60">
+          <p
+            id="upload-box-subtitle"
+            className="flex items-center gap-1 rounded-full border border-white/30 bg-white/5 px-3 py-0.5 text-center text-sm text-white/60"
+          >
             {subtitleIcon}
             {subtitle}
           </p>
@@ -34,15 +39,15 @@ export function UploadBox({
         role="group"
         aria-labelledby="upload-box-title"
         aria-describedby="upload-box-instructions"
-        className="flex flex-col items-center justify-center gap-4 w-full sm:w-container max-w-container rounded-xl border-2 border-dashed border-white/30 bg-white/5 p-6 backdrop-blur-sm"
+        className="flex w-full max-w-container flex-col items-center justify-center gap-4 rounded-xl border-2 border-dashed border-white/30 bg-white/5 p-6 backdrop-blur-sm sm:w-container"
       >
         <UploadIcon className="size-8 text-gray-500" />
-        <p className="font-medium text-sm text-gray-500">Drag and Drop</p>
-        <p className="font-medium text-sm text-gray-500">or</p>
+        <p className="text-sm font-medium text-gray-500">Drag and Drop</p>
+        <p className="text-sm font-medium text-gray-500">or</p>
         <label
           role="button"
           tabIndex={0}
-          className="inline-flex cursor-pointer items-center gap-2 rounded-lg bg-blue-600 h-10 px-4 py-2 font-semibold text-sm text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
+          className="inline-flex h-10 cursor-pointer items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
         >
           <span>{description}</span>
           <input

--- a/src/components/shared/upload-box.tsx
+++ b/src/components/shared/upload-box.tsx
@@ -3,6 +3,7 @@ import React from "react";
 interface UploadBoxProps {
   title: string;
   subtitle?: string;
+  subtitleIcon?: React.ElementType;
   description: string;
   accept: string;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -11,6 +12,7 @@ interface UploadBoxProps {
 export function UploadBox({
   title,
   subtitle,
+  subtitleIcon: SubtitleIcon,
   description,
   accept,
   onChange,
@@ -21,6 +23,7 @@ export function UploadBox({
         <p id="upload-box-title" className="text-center text-white">{title}</p>
         {subtitle && (
           <p id="upload-box-subtitle" className="flex gap-1 items-center rounded-full border border-white/30 bg-white/5 px-3 py-0.5 text-center text-sm text-white/60">
+            {SubtitleIcon && <SubtitleIcon />}
             {subtitle}
           </p>
         )}

--- a/src/components/shared/upload-box.tsx
+++ b/src/components/shared/upload-box.tsx
@@ -42,7 +42,7 @@ export function UploadBox({
         <label
           role="button"
           tabIndex={0}
-          className="inline-flex cursor-pointer items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
+          className="inline-flex cursor-pointer items-center gap-2 rounded-lg bg-blue-600 h-10 px-4 py-2 font-semibold text-sm text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
         >
           <span>{description}</span>
           <input

--- a/src/components/shared/upload-box.tsx
+++ b/src/components/shared/upload-box.tsx
@@ -16,16 +16,21 @@ export function UploadBox({
   onChange,
 }: UploadBoxProps) {
   return (
-    <div className="flex flex-col items-center justify-center gap-4 p-4">
+    <div className="flex flex-col items-center justify-center gap-4 w-full">
       <div className="flex flex-col items-center gap-2">
-        <p className="text-center text-white">{title}</p>
+        <p id="upload-box-title" className="text-center text-white">{title}</p>
         {subtitle && (
-          <p className="inline-block rounded-full border border-white/30 bg-white/5 px-2 py-0.5 text-center text-sm text-white/60">
+          <p id="upload-box-subtitle" className="flex gap-1 items-center rounded-full border border-white/30 bg-white/5 px-3 py-0.5 text-center text-sm text-white/60">
             {subtitle}
           </p>
         )}
       </div>
-      <div className="flex w-72 flex-col items-center justify-center gap-4 rounded-xl border-2 border-dashed border-white/30 bg-white/10 p-6 backdrop-blur-sm">
+      <div
+        role="group"
+        aria-labelledby="upload-box-title"
+        aria-describedby="upload-box-instructions"
+        className="flex flex-col items-center justify-center gap-4 w-full sm:w-container max-w-container rounded-xl border-2 border-dashed border-white/30 bg-white/5 p-6 backdrop-blur-sm"
+      >
         <svg
           className="h-8 w-8 text-gray-400"
           fill="none"
@@ -39,15 +44,22 @@ export function UploadBox({
             d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
           />
         </svg>
-        <p className="text-sm text-gray-400">Drag and Drop</p>
-        <p className="text-sm text-gray-500">or</p>
-        <label className="inline-flex cursor-pointer items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75">
+        <p className="font-medium text-sm text-gray-500">Drag and Drop</p>
+        <p className="font-medium text-sm text-gray-500">or</p>
+        <label
+          role="button"
+          tabIndex={0}
+          className="inline-flex cursor-pointer items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
+        >
           <span>{description}</span>
           <input
             type="file"
             onChange={onChange}
             accept={accept}
             className="hidden"
+            aria-labelledby="upload-box-title"
+            aria-describedby="upload-box-instructions"
+            aria-hidden="true"
           />
         </label>
       </div>

--- a/src/components/shared/upload-box.tsx
+++ b/src/components/shared/upload-box.tsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { useRef } from "react";
 
 import { UploadIcon } from "@/components/shared/icons";
+
+import { useKeyDown } from "@/hooks/use-keydown";
 
 interface UploadBoxProps {
   title: string;
@@ -19,6 +21,18 @@ export function UploadBox({
   accept,
   onChange,
 }: UploadBoxProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const fileInputLabelRef = useRef<HTMLLabelElement>(null);
+
+  useKeyDown(["Enter", "Space"], () => {
+    if (
+      fileInputRef.current &&
+      document.activeElement === fileInputLabelRef.current
+    ) {
+      fileInputRef.current.click();
+    }
+  });
+
   return (
     <div className="flex w-full flex-col items-center justify-center gap-4">
       <div className="flex flex-col items-center gap-2">
@@ -45,12 +59,14 @@ export function UploadBox({
         <p className="text-sm font-medium text-gray-500">Drag and Drop</p>
         <p className="text-sm font-medium text-gray-500">or</p>
         <label
+          ref={fileInputLabelRef}
           role="button"
           tabIndex={0}
           className="inline-flex h-10 cursor-pointer items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-200 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75"
         >
           <span>{description}</span>
           <input
+            ref={fileInputRef}
             type="file"
             onChange={onChange}
             accept={accept}

--- a/src/components/svg-scale-selector.tsx
+++ b/src/components/svg-scale-selector.tsx
@@ -4,13 +4,15 @@ import { Select } from "@/components/shared/select";
 
 import { useMediaQuery } from "@/hooks/use-media-query";
 
-type CustomValueChangeEventContext = {
-  e: React.KeyboardEvent<HTMLInputElement>;
-  context: 'keyboard';
-} | {
-  e: React.MouseEvent<HTMLButtonElement, MouseEvent>;
-  context: 'button-up' | 'button-down';
-}
+type CustomValueChangeEventContext =
+  | {
+      e: React.KeyboardEvent<HTMLInputElement>;
+      context: "keyboard";
+    }
+  | {
+      e: React.MouseEvent<HTMLButtonElement, MouseEvent>;
+      context: "button-up" | "button-down";
+    };
 
 interface SVGScaleSelectorProps {
   customValue?: number | null;
@@ -45,24 +47,28 @@ export function SVGScaleSelector({
     if (/^(\d+\.?\d*|\.\d*)?$/.test(rawInput)) {
       onCustomValueChange?.(rawInput === "" ? null : parseFloat(rawInput));
     }
-  }
+  };
 
   // but handle most of the validation on blur, which allows the user to clear the input
   // completely, so they can type anything—including values that begin with "0", like "0.25"
   const handleInputBlur = () => {
     // Empty input and invalid (NaN) input should cause the input to be reset to 1
-    if (customValue === null || customValue === undefined || isNaN(customValue)) {
+    if (
+      customValue === null ||
+      customValue === undefined ||
+      isNaN(customValue)
+    ) {
       onCustomValueChange?.(1);
       return;
     }
-    
+
     // Remove leading and trailing whitespace
     let normalizedValue = customValue.toString().trim();
 
     // Decimal values should always have a single leading zero
     if (normalizedValue.startsWith("."))
       normalizedValue = "0" + normalizedValue;
-    
+
     // Decimal values should always have only one leading zero
     if (/^0+\d+$/.test(normalizedValue))
       normalizedValue = String(parseFloat(normalizedValue));
@@ -75,14 +81,21 @@ export function SVGScaleSelector({
     if (normalizedValue === "0") normalizedValue = "1";
 
     // Parse the normalized value as a number, clamp it to the range 0 < value <= 64, and set state
-    const clampedValue = Math.min(64, Math.max(Number.MIN_VALUE, parseFloat(normalizedValue)));
+    const clampedValue = Math.min(
+      64,
+      Math.max(Number.MIN_VALUE, parseFloat(normalizedValue)),
+    );
     onCustomValueChange?.(clampedValue);
-  }
+  };
 
   // a generalized handler for custom value changes which can operate in different contexts—keyboard/keydown
   // on the custom value input itself, or pointer/click on the custom value input's increment/decrement buttons
-  const handleCustomValueStep = ({ e, context }: CustomValueChangeEventContext) => {
-    if (context === 'keyboard' && e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+  const handleCustomValueStep = ({
+    e,
+    context,
+  }: CustomValueChangeEventContext) => {
+    if (context === "keyboard" && e.key !== "ArrowUp" && e.key !== "ArrowDown")
+      return;
 
     e.preventDefault();
     const currentValue = customValue ?? 0.1;
@@ -90,9 +103,9 @@ export function SVGScaleSelector({
 
     if (e.shiftKey) step = 10;
     if (e.altKey) step = 0.1;
-    
+
     const newValue =
-      (context === 'keyboard' && e.key === "ArrowUp") || (context === 'button-up')
+      (context === "keyboard" && e.key === "ArrowUp") || context === "button-up"
         ? (currentValue || 0) + step
         : (currentValue || 0) - step;
 
@@ -102,10 +115,11 @@ export function SVGScaleSelector({
     );
 
     onCustomValueChange?.(clampedValue);
-  }
+  };
 
   useEffect(() => {
-    if (!selectedRef.current || !highlightRef.current || !containerRef.current) return;
+    if (!selectedRef.current || !highlightRef.current || !containerRef.current)
+      return;
 
     // prevent layout thrashing
     requestAnimationFrame(() => {
@@ -120,24 +134,30 @@ export function SVGScaleSelector({
       highlight.style.width = `${selectedRect.width}px`;
     });
 
-  // though isXsScreen is not a real dependency, the selected scale option must
-  // be re-rerendered when it changes, because otherwise the highlight will be
-  // missing/not calculated when the user resizes the window and the scale selector
-  // switches between its two different display modes
+    // though isXsScreen is not a real dependency, the selected scale option must
+    // be re-rerendered when it changes, because otherwise the highlight will be
+    // missing/not calculated when the user resizes the window and the scale selector
+    // switches between its two different display modes
   }, [selected, isXsScreen]);
 
   return (
-    <div className={`${isXsScreen ? "w-full" : ""} flex flex-col items-center gap-2`}> 
+    <div
+      className={`${isXsScreen ? "w-full" : ""} flex flex-col items-center gap-2`}
+    >
       <span className="text-sm text-white/60">{title}</span>
-      <div className={`flex ${isXsScreen ? "flex-row w-full" : "flex-col"} items-center justify-center gap-2`}>
+      <div
+        className={`flex ${isXsScreen ? "w-full flex-row" : "flex-col"} items-center justify-center gap-2`}
+      >
         {isXsScreen ? (
           <Select
             placeholder="Select scale…"
-            options={[ ...options, "custom" as const ]}
+            options={[...options, "custom" as const]}
             selected={selected}
             onChange={onChange}
-            formatOption={(option: number | "custom") => option === "custom" ? "Custom" : `${option}×`}
-            className="flex-1 basis-1/2 w-full min-w-0"
+            formatOption={(option: number | "custom") =>
+              option === "custom" ? "Custom" : `${option}×`
+            }
+            className="w-full min-w-0 flex-1 basis-1/2"
           />
         ) : (
           <div
@@ -155,7 +175,7 @@ export function SVGScaleSelector({
                 onClick={() =>
                   onChange(typeof option === "number" ? option : "custom")
                 }
-                className={`option relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-none ${
+                className={`option focus:ring-none relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none ${
                   option === selected
                     ? "text-white"
                     : "text-white/60 hover:text-white focus:bg-white/10"
@@ -167,7 +187,9 @@ export function SVGScaleSelector({
           </div>
         )}
         {selected === "custom" && (
-          <div className={`${isXsScreen ? "flex-1 basis-1/2 w-full min-w-0" : "w-36"} group relative flex items-center`}>
+          <div
+            className={`${isXsScreen ? "w-full min-w-0 flex-1 basis-1/2" : "w-36"} group relative flex items-center`}
+          >
             <input
               ref={customValueInputRef}
               type="number"
@@ -177,38 +199,74 @@ export function SVGScaleSelector({
               value={customValue === null ? "" : customValue}
               onChange={handleInputChange}
               onBlur={handleInputBlur}
-              onKeyDown={(e) => handleCustomValueStep({ e, context: 'keyboard' })}
-              className="w-full h-10 rounded-lg px-3 pr-10 py-2 text-sm font-medium bg-white/5 text-white/60 hover:text-white group-hover:text-white group-focus-within:text-white placeholder:text-gray-500 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 focus-visible:ring-offset-none group-focus-within:ring-2 group-focus-within:ring-white/30 disabled:cursor-not-allowed disabled:opacity-50 [&::-webkit-inner-spin-button]:[-webkit-appearance:none] [&::-webkit-outer-spin-button]:[-webkit-appearance:none] [&::-webkit-inner-spin-button]:opacity-0 [&::-webkit-outer-spin-button]:opacity-0"
+              onKeyDown={(e) =>
+                handleCustomValueStep({ e, context: "keyboard" })
+              }
+              className="focus-visible:ring-offset-none h-10 w-full rounded-lg bg-white/5 px-3 py-2 pr-10 text-sm font-medium text-white/60 transition-colors duration-200 placeholder:text-gray-500 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 disabled:cursor-not-allowed disabled:opacity-50 group-focus-within:text-white group-focus-within:ring-2 group-focus-within:ring-white/30 group-hover:text-white [&::-webkit-inner-spin-button]:opacity-0 [&::-webkit-inner-spin-button]:[-webkit-appearance:none] [&::-webkit-outer-spin-button]:opacity-0 [&::-webkit-outer-spin-button]:[-webkit-appearance:none]"
               placeholder="Enter scale"
             />
-            <span className="absolute right-8 font-medium text-sm text-gray-500">×</span>
+            <span className="absolute right-8 text-sm font-medium text-gray-500">
+              ×
+            </span>
             <button
               ref={customValueIncrementRef}
-              className="absolute right-2 top-2 flex items-center justify-center w-4 h-3 cursor-pointer transition-colors duration-200 text-gray-500 hover:text-white focus:rounded-sm focus:outline-none focus:ring-none focus:text-white focus:bg-white/10"
-              onClick={(e) => handleCustomValueStep({ e, context: 'button-up' })}
+              className="focus:ring-none absolute right-2 top-2 flex h-3 w-4 cursor-pointer items-center justify-center text-gray-500 transition-colors duration-200 hover:text-white focus:rounded-sm focus:bg-white/10 focus:text-white focus:outline-none"
+              onClick={(e) =>
+                handleCustomValueStep({ e, context: "button-up" })
+              }
               onMouseLeave={() => {
                 // prevent increment/decrement buttons from retaining focus after click and even after mouseleave
-                if (document.activeElement === customValueIncrementRef.current) {
+                if (
+                  document.activeElement === customValueIncrementRef.current
+                ) {
                   customValueIncrementRef.current?.blur();
                   customValueInputRef.current?.focus();
                 }
               }}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="m18 15-6-6-6 6"/></svg>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width={16}
+                height={16}
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="m18 15-6-6-6 6" />
+              </svg>
             </button>
             <button
               ref={customValueDecrementRef}
-              className="absolute right-2 bottom-2 flex items-center justify-center w-4 h-3 cursor-pointer transition-colors duration-200 text-gray-500 hover:text-white focus:rounded-sm focus:outline-none focus:ring-none focus:text-white focus:bg-white/10"
-              onClick={(e) => handleCustomValueStep({ e, context: 'button-down' })}
+              className="focus:ring-none absolute bottom-2 right-2 flex h-3 w-4 cursor-pointer items-center justify-center text-gray-500 transition-colors duration-200 hover:text-white focus:rounded-sm focus:bg-white/10 focus:text-white focus:outline-none"
+              onClick={(e) =>
+                handleCustomValueStep({ e, context: "button-down" })
+              }
               onMouseLeave={() => {
                 // prevent increment/decrement buttons from retaining focus after click and even after mouseleave
-                if (document.activeElement === customValueIncrementRef.current) {
+                if (
+                  document.activeElement === customValueIncrementRef.current
+                ) {
                   customValueIncrementRef.current?.blur();
                   customValueInputRef.current?.focus();
                 }
               }}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width={16}
+                height={16}
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="m6 9 6 6 6-6" />
+              </svg>
             </button>
           </div>
         )}

--- a/src/components/svg-scale-selector.tsx
+++ b/src/components/svg-scale-selector.tsx
@@ -1,12 +1,20 @@
-import React, { useRef, useEffect } from "react";
+import React, { useEffect, useRef } from "react";
+
+type CustomValueChangeEventContext = {
+  e: React.KeyboardEvent<HTMLInputElement>;
+  context: 'keyboard';
+} | {
+  e: React.MouseEvent<HTMLButtonElement, MouseEvent>;
+  context: 'button-up' | 'button-down';
+}
 
 interface SVGScaleSelectorProps {
   title: string;
   options: number[];
   selected: number | "custom";
   onChange: (value: number | "custom") => void;
-  customValue?: number;
-  onCustomValueChange?: (value: number) => void;
+  customValue?: number | null;
+  onCustomValueChange?: (value: number | null) => void;
 }
 
 export function SVGScaleSelector({
@@ -20,25 +28,98 @@ export function SVGScaleSelector({
   const containerRef = useRef<HTMLDivElement>(null);
   const selectedRef = useRef<HTMLButtonElement>(null);
   const highlightRef = useRef<HTMLDivElement>(null);
+  const customValueInputRef = useRef<HTMLInputElement>(null);
+  const customValueIncrementRef = useRef<HTMLButtonElement>(null);
+  const customValueDecrementRef = useRef<HTMLButtonElement>(null);
+
+  // handle basic validation on the change event
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const rawInput = e.target.value;
+
+    // If the input is a valid number, set state (empty string should become null)
+    if (/^(\d+\.?\d*|\.\d*)?$/.test(rawInput)) {
+      onCustomValueChange?.(rawInput === "" ? null : parseFloat(rawInput));
+    }
+  }
+
+  // but handle most of the validation on blur, which allows the user to clear the input
+  // completely, so they can type anything—including values that begin with "0", like "0.25"
+  const handleInputBlur = () => {
+    // Empty input and invalid (NaN) input should cause the input to be reset to 1
+    if (customValue === null || customValue === undefined || isNaN(customValue)) {
+      onCustomValueChange?.(1);
+      return;
+    }
+    
+    // Remove leading and trailing whitespace
+    let normalizedValue = customValue.toString().trim();
+
+    // Decimal values should always have a single leading zero
+    if (normalizedValue.startsWith("."))
+      normalizedValue = "0" + normalizedValue;
+    
+    // Decimal values should always have only one leading zero
+    if (/^0+\d+$/.test(normalizedValue))
+      normalizedValue = String(parseFloat(normalizedValue));
+
+    // Decimal values should never have trailing zeroes
+    if (normalizedValue.includes("."))
+      normalizedValue = parseFloat(normalizedValue).toString();
+
+    // Values of 0 should be normalized to 1
+    if (normalizedValue === "0") normalizedValue = "1";
+
+    // Parse the normalized value as a number, clamp it to the range 0 < value <= 64, and set state
+    const clampedValue = Math.min(64, Math.max(Number.MIN_VALUE, parseFloat(normalizedValue)));
+    onCustomValueChange?.(clampedValue);
+  }
+
+  // a generalized handler for custom value changes which can operate in different contexts—keyboard/keydown
+  // on the custom value input itself, or pointer/click on the custom value input's increment/decrement buttons
+  const handleCustomValueStep = ({ e, context }: CustomValueChangeEventContext) => {
+    if (context === 'keyboard' && e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+
+    e.preventDefault();
+    const currentValue = customValue ?? 0.1;
+    let step = 1;
+
+    if (e.shiftKey) step = 10;
+    if (e.altKey) step = 0.1;
+    
+    const newValue =
+      (context === 'keyboard' && e.key === "ArrowUp") || (context === 'button-up')
+        ? (currentValue || 0) + step
+        : (currentValue || 0) - step;
+
+    const clampedValue = Math.min(
+      64,
+      Math.max(e.altKey ? 0.1 : 1, Number(newValue.toFixed(1))),
+    );
+
+    onCustomValueChange?.(clampedValue);
+  }
 
   useEffect(() => {
-    if (selectedRef.current && highlightRef.current && containerRef.current) {
-      const container = containerRef.current;
-      const selected = selectedRef.current;
-      const highlight = highlightRef.current;
+    if (!selectedRef.current || !highlightRef.current || !containerRef.current) return;
+
+    // prevent layout thrashing
+    requestAnimationFrame(() => {
+      const container = containerRef.current!;
+      const selected = selectedRef.current!;
+      const highlight = highlightRef.current!;
 
       const containerRect = container.getBoundingClientRect();
       const selectedRect = selected.getBoundingClientRect();
 
       highlight.style.left = `${selectedRect.left - containerRect.left}px`;
       highlight.style.width = `${selectedRect.width}px`;
-    }
+    });
   }, [selected]);
 
   return (
     <div className="flex flex-col items-center gap-2">
       <span className="text-sm text-white/60">{title}</span>
-      <div className="flex flex-col items-center gap-2">
+      <div className="flex flex-col items-center justify-center gap-2">
         <div
           ref={containerRef}
           className="relative inline-flex rounded-lg bg-white/5 p-1"
@@ -54,10 +135,10 @@ export function SVGScaleSelector({
               onClick={() =>
                 onChange(typeof option === "number" ? option : "custom")
               }
-              className={`relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+              className={`option relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-none ${
                 option === selected
                   ? "text-white"
-                  : "text-white/80 hover:text-white"
+                  : "text-white/60 hover:text-white focus:bg-white/10"
               }`}
             >
               {option === "custom" ? "Custom" : `${option}×`}
@@ -65,38 +146,50 @@ export function SVGScaleSelector({
           ))}
         </div>
         {selected === "custom" && (
-          <input
-            type="number"
-            min="0"
-            max="64"
-            step="1"
-            value={customValue}
-            onChange={(e) => {
-              const value = Math.min(64, parseFloat(e.target.value));
-              onCustomValueChange?.(value);
-            }}
-            onKeyDown={(e) => {
-              if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
-
-              e.preventDefault();
-              const currentValue = customValue ?? 0;
-              let step = 1;
-
-              if (e.shiftKey) step = 10;
-              if (e.altKey) step = 0.1;
-
-              const newValue =
-                e.key === "ArrowUp" ? currentValue + step : currentValue - step;
-
-              const clampedValue = Math.min(
-                64,
-                Math.max(0, Number(newValue.toFixed(1))),
-              );
-              onCustomValueChange?.(clampedValue);
-            }}
-            className="w-24 rounded-lg bg-white/5 px-3 py-1.5 text-sm text-white"
-            placeholder="Enter scale"
-          />
+          <div className="w-36 group relative flex items-center"> 
+            <input
+              ref={customValueInputRef}
+              type="number"
+              min="1"
+              max="64"
+              step="1"
+              value={customValue === null ? "" : customValue}
+              onChange={handleInputChange}
+              onBlur={handleInputBlur}
+              onKeyDown={(e) => handleCustomValueStep({ e, context: 'keyboard' })}
+              className="w-full h-10 rounded-lg px-3 pr-10 py-2 text-sm font-medium bg-white/5 text-white/60 hover:text-white group-hover:text-white group-focus-within:text-white placeholder:text-gray-500 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 focus-visible:ring-offset-none group-focus-within:ring-2 group-focus-within:ring-white/30 disabled:cursor-not-allowed disabled:opacity-50 [&::-webkit-inner-spin-button]:[-webkit-appearance:none] [&::-webkit-outer-spin-button]:[-webkit-appearance:none] [&::-webkit-inner-spin-button]:opacity-0 [&::-webkit-outer-spin-button]:opacity-0"
+              placeholder="Enter scale"
+            />
+            <span className="absolute right-8 font-medium text-sm text-gray-500">×</span>
+            <button
+              ref={customValueIncrementRef}
+              className="absolute right-2 top-2 flex items-center justify-center w-4 h-3 cursor-pointer transition-colors duration-200 text-gray-500 hover:text-white focus:rounded-sm focus:outline-none focus:ring-none focus:text-white focus:bg-white/10"
+              onClick={(e) => handleCustomValueStep({ e, context: 'button-up' })}
+              onMouseLeave={() => {
+                // prevent increment/decrement buttons from retaining focus after click and even after mouseleave
+                if (document.activeElement === customValueIncrementRef.current) {
+                  customValueIncrementRef.current?.blur();
+                  customValueInputRef.current?.focus();
+                }
+              }}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="m18 15-6-6-6 6"/></svg>
+            </button>
+            <button
+              ref={customValueDecrementRef}
+              className="absolute right-2 bottom-2 flex items-center justify-center w-4 h-3 cursor-pointer transition-colors duration-200 text-gray-500 hover:text-white focus:rounded-sm focus:outline-none focus:ring-none focus:text-white focus:bg-white/10"
+              onClick={(e) => handleCustomValueStep({ e, context: 'button-down' })}
+              onMouseLeave={() => {
+                // prevent increment/decrement buttons from retaining focus after click and even after mouseleave
+                if (document.activeElement === customValueIncrementRef.current) {
+                  customValueIncrementRef.current?.blur();
+                  customValueInputRef.current?.focus();
+                }
+              }}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+            </button>
+          </div>
         )}
       </div>
     </div>

--- a/src/components/svg-scale-selector.tsx
+++ b/src/components/svg-scale-selector.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect, useRef } from "react";
 
+import { Select } from "@/components/shared/select";
+
+import { useMediaQuery } from "@/hooks/use-media-query";
+
 type CustomValueChangeEventContext = {
   e: React.KeyboardEvent<HTMLInputElement>;
   context: 'keyboard';
@@ -9,22 +13,23 @@ type CustomValueChangeEventContext = {
 }
 
 interface SVGScaleSelectorProps {
-  title: string;
+  customValue?: number | null;
+  onChange: (value: number | "custom") => void;
+  onCustomValueChange?: (value: number | null) => void;
   options: number[];
   selected: number | "custom";
-  onChange: (value: number | "custom") => void;
-  customValue?: number | null;
-  onCustomValueChange?: (value: number | null) => void;
+  title: string;
 }
 
 export function SVGScaleSelector({
-  title,
+  customValue,
+  onChange,
+  onCustomValueChange,
   options,
   selected,
-  onChange,
-  customValue,
-  onCustomValueChange,
+  title,
 }: SVGScaleSelectorProps) {
+  const isXsScreen = useMediaQuery("(max-width: 29rem)");
   const containerRef = useRef<HTMLDivElement>(null);
   const selectedRef = useRef<HTMLButtonElement>(null);
   const highlightRef = useRef<HTMLDivElement>(null);
@@ -114,39 +119,55 @@ export function SVGScaleSelector({
       highlight.style.left = `${selectedRect.left - containerRect.left}px`;
       highlight.style.width = `${selectedRect.width}px`;
     });
-  }, [selected]);
+
+  // though isXsScreen is not a real dependency, the selected scale option must
+  // be re-rerendered when it changes, because otherwise the highlight will be
+  // missing/not calculated when the user resizes the window and the scale selector
+  // switches between its two different display modes
+  }, [selected, isXsScreen]);
 
   return (
-    <div className="flex flex-col items-center gap-2">
+    <div className={`${isXsScreen ? "w-full" : ""} flex flex-col items-center gap-2`}> 
       <span className="text-sm text-white/60">{title}</span>
-      <div className="flex flex-col items-center justify-center gap-2">
-        <div
-          ref={containerRef}
-          className="relative inline-flex rounded-lg bg-white/5 p-1"
-        >
-          <div
-            ref={highlightRef}
-            className="absolute top-1 h-[calc(100%-8px)] rounded-md bg-blue-600 transition-all duration-200"
+      <div className={`flex ${isXsScreen ? "flex-row w-full" : "flex-col"} items-center justify-center gap-2`}>
+        {isXsScreen ? (
+          <Select
+            placeholder="Select scale…"
+            options={[ ...options, "custom" as const ]}
+            selected={selected}
+            onChange={onChange}
+            formatOption={(option: number | "custom") => option === "custom" ? "Custom" : `${option}×`}
+            className="flex-1 basis-1/2 w-full min-w-0"
           />
-          {[...options, "custom" as const].map((option) => (
-            <button
-              key={String(option)}
-              ref={option === selected ? selectedRef : null}
-              onClick={() =>
-                onChange(typeof option === "number" ? option : "custom")
-              }
-              className={`option relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-none ${
-                option === selected
-                  ? "text-white"
-                  : "text-white/60 hover:text-white focus:bg-white/10"
-              }`}
-            >
-              {option === "custom" ? "Custom" : `${option}×`}
-            </button>
-          ))}
-        </div>
+        ) : (
+          <div
+            ref={containerRef}
+            className="relative inline-flex rounded-lg bg-white/5 p-1"
+          >
+            <div
+              ref={highlightRef}
+              className="absolute top-1 h-[calc(100%-8px)] rounded-md bg-blue-600 transition-all duration-200"
+            />
+            {[...options, "custom" as const].map((option) => (
+              <button
+                key={String(option)}
+                ref={option === selected ? selectedRef : null}
+                onClick={() =>
+                  onChange(typeof option === "number" ? option : "custom")
+                }
+                className={`option relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-none ${
+                  option === selected
+                    ? "text-white"
+                    : "text-white/60 hover:text-white focus:bg-white/10"
+                }`}
+              >
+                {option === "custom" ? "Custom" : `${option}×`}
+              </button>
+            ))}
+          </div>
+        )}
         {selected === "custom" && (
-          <div className="w-36 group relative flex items-center"> 
+          <div className={`${isXsScreen ? "flex-1 basis-1/2 w-full min-w-0" : "w-36"} group relative flex items-center`}>
             <input
               ref={customValueInputRef}
               type="number"

--- a/src/hooks/use-callback-ref.ts
+++ b/src/hooks/use-callback-ref.ts
@@ -1,8 +1,10 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from "react";
 
 // inspired by Radix UI: https://github.com/radix-ui/primitives/blob/main/packages/react/use-callback-ref/src/use-callback-ref.tsx
 // converts a callback function into a stable reference that avoids triggering re-renders or re-running effects/re-registering event listeners
-export function useCallbackRef<T extends (...args: Parameters<T>) => ReturnType<T>>(callback?: T): T {
+export function useCallbackRef<
+  T extends (...args: Parameters<T>) => ReturnType<T>,
+>(callback?: T): T {
   const callbackRef = useRef(callback);
 
   useEffect(() => {

--- a/src/hooks/use-callback-ref.ts
+++ b/src/hooks/use-callback-ref.ts
@@ -1,0 +1,13 @@
+import { useEffect, useMemo, useRef } from 'react';
+
+// inspired by Radix UI: https://github.com/radix-ui/primitives/blob/main/packages/react/use-callback-ref/src/use-callback-ref.tsx
+// converts a callback function into a stable reference that avoids triggering re-renders or re-running effects/re-registering event listeners
+export function useCallbackRef<T extends (...args: Parameters<T>) => ReturnType<T>>(callback?: T): T {
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  return useMemo(() => ((...args) => callbackRef.current?.(...args)) as T, []);
+}

--- a/src/hooks/use-clipboard-paste.ts
+++ b/src/hooks/use-clipboard-paste.ts
@@ -2,14 +2,18 @@
 
 import { useEffect, useCallback } from "react";
 
+import { type FileTypeString, generateFileTypesString } from "@/lib/file-utils";
+
 interface UseClipboardPasteProps {
+  acceptedFileTypes: FileTypeString[];
+  onError?: (error: string) => void;
   onPaste: (file: File) => void;
-  acceptedFileTypes: string[];
 }
 
 export function useClipboardPaste({
-  onPaste,
   acceptedFileTypes,
+  onError,
+  onPaste,
 }: UseClipboardPasteProps) {
   const handlePaste = useCallback(
     async (event: ClipboardEvent) => {
@@ -17,6 +21,8 @@ export function useClipboardPaste({
       if (!items) return;
 
       for (const item of Array.from(items)) {
+        if (item.kind === "string") break;
+        
         if (item.type.startsWith("image/")) {
           const file = item.getAsFile();
           if (!file) continue;
@@ -28,15 +34,26 @@ export function useClipboardPaste({
               file.name.toLowerCase().endsWith(type.replace("*", "")),
           );
 
+          const acceptedFileTypesString = generateFileTypesString(acceptedFileTypes);
+
+          event.preventDefault();
+
           if (isAcceptedType) {
-            event.preventDefault();
             onPaste(file);
             break;
+          } else {
+            if (onError) onError(`Pasted image has invalid type. Valid types are: ${acceptedFileTypesString}.`);
+            else alert(`Pasted image has invalid type. Valid types are: ${acceptedFileTypesString}.`);
+            break;
           }
+        } else {
+          if (onError) onError(`Pasted file is not an image. Please upload a valid image file.`);
+          else alert(`Pasted file is not an image. Please upload a valid image file.`);
+          break;
         }
       }
     },
-    [onPaste, acceptedFileTypes],
+    [acceptedFileTypes, onError, onPaste],
   );
 
   useEffect(() => {

--- a/src/hooks/use-clipboard-paste.ts
+++ b/src/hooks/use-clipboard-paste.ts
@@ -22,7 +22,7 @@ export function useClipboardPaste({
 
       for (const item of Array.from(items)) {
         if (item.kind === "string") break;
-        
+
         if (item.type.startsWith("image/")) {
           const file = item.getAsFile();
           if (!file) continue;
@@ -34,7 +34,8 @@ export function useClipboardPaste({
               file.name.toLowerCase().endsWith(type.replace("*", "")),
           );
 
-          const acceptedFileTypesString = generateFileTypesString(acceptedFileTypes);
+          const acceptedFileTypesString =
+            generateFileTypesString(acceptedFileTypes);
 
           event.preventDefault();
 
@@ -42,13 +43,25 @@ export function useClipboardPaste({
             onPaste(file);
             break;
           } else {
-            if (onError) onError(`Pasted image has invalid type. Valid types are: ${acceptedFileTypesString}.`);
-            else alert(`Pasted image has invalid type. Valid types are: ${acceptedFileTypesString}.`);
+            if (onError)
+              onError(
+                `Pasted image has invalid type. Valid types are: ${acceptedFileTypesString}.`,
+              );
+            else
+              alert(
+                `Pasted image has invalid type. Valid types are: ${acceptedFileTypesString}.`,
+              );
             break;
           }
         } else {
-          if (onError) onError(`Pasted file is not an image. Please upload a valid image file.`);
-          else alert(`Pasted file is not an image. Please upload a valid image file.`);
+          if (onError)
+            onError(
+              `Pasted file is not an image. Please upload a valid image file.`,
+            );
+          else
+            alert(
+              `Pasted file is not an image. Please upload a valid image file.`,
+            );
           break;
         }
       }

--- a/src/hooks/use-file-fetcher.ts
+++ b/src/hooks/use-file-fetcher.ts
@@ -23,26 +23,30 @@ export type FileFetcherResult = {
   cancel: () => void;
 };
 
-type FileFetcherFormState = Pick<FileFetcherResult, "error">
+type FileFetcherFormState = Pick<FileFetcherResult, "error">;
 
 type FileFetcherOptions = {
   onError?: (error: string) => void;
-}
+};
 
 export function useFileFetcher({ onError }: FileFetcherOptions = {}) {
   const { imageContent, rawContent, imageMetadata, processFile, cancel } =
     useProcessFile({ onError });
 
-  const [state, handleFetchFile, pending] = useActionState<FileFetcherFormState, FormData>(
+  const [state, handleFetchFile, pending] = useActionState<
+    FileFetcherFormState,
+    FormData
+  >(
     async (_, formData: FormData): Promise<FileFetcherFormState> => {
       const input = formData.get("url") as string;
       const accept = formData.get("accept") as string | null;
-      
+
       if (!input) return { error: "URL is required." };
       if (!accept) return { error: "Image has invalid or missing MIME type." };
 
       const validUrl = validateUrl(input);
-      if (!validUrl) return { error: "Invalid URL. Please check and try again." };
+      if (!validUrl)
+        return { error: "Invalid URL. Please check and try again." };
 
       try {
         const response = await fetch(validUrl);
@@ -50,9 +54,14 @@ export function useFileFetcher({ onError }: FileFetcherOptions = {}) {
         if (!response.ok) {
           switch (response.status) {
             case 400:
-              return { error: "Invalid request. Please check the URL and try again." };
+              return {
+                error: "Invalid request. Please check the URL and try again.",
+              };
             case 403:
-              return { error: "Forbidden—you don't have permission to access this resource." };
+              return {
+                error:
+                  "Forbidden—you don't have permission to access this resource.",
+              };
             case 404:
               return { error: "Image not found. Please check the URL." };
             case 500:
@@ -61,19 +70,24 @@ export function useFileFetcher({ onError }: FileFetcherOptions = {}) {
               return { error: "Service unavailable. Please try again later." };
             default:
               let errorMessage = response.status + "";
-              if (HTTP_ERROR_CODES.has(response.status)) errorMessage += ` ${HTTP_ERROR_CODES.get(response.status)}`;
-              return { error: `Failed to retrieve image (Error: ${errorMessage}).` };
+              if (HTTP_ERROR_CODES.has(response.status))
+                errorMessage += ` ${HTTP_ERROR_CODES.get(response.status)}`;
+              return {
+                error: `Failed to retrieve image (Error: ${errorMessage}).`,
+              };
           }
         }
 
         const fileType = response.headers.get("Content-Type") ?? "";
 
         if (!fileType.startsWith("image/")) {
-          return { error: `Requested file is not an image. Please upload a valid image file.` };
+          return {
+            error: `Requested file is not an image. Please upload a valid image file.`,
+          };
         }
-        
+
         let fileExt = "",
-            fileContent: string | ArrayBuffer;
+          fileContent: string | ArrayBuffer;
 
         if (fileType.startsWith("image/")) {
           fileExt = fileType.split("/").pop() ?? "";
@@ -82,13 +96,19 @@ export function useFileFetcher({ onError }: FileFetcherOptions = {}) {
         }
 
         const isSvg = fileType === "image/svg+xml";
-        const isValidType = accept === "image/*" || fileType.startsWith(accept) || (accept.includes(".svg") && isSvg);
+        const isValidType =
+          accept === "image/*" ||
+          fileType.startsWith(accept) ||
+          (accept.includes(".svg") && isSvg);
 
         if (!isValidType) {
-          return { error: `Requested image has invalid type. Valid types are: ${accept}.` };
+          return {
+            error: `Requested image has invalid type. Valid types are: ${accept}.`,
+          };
         }
 
-        const fileName = new URL(validUrl).pathname.split("/").pop()?.split(".")[0] ?? "image";
+        const fileName =
+          new URL(validUrl).pathname.split("/").pop()?.split(".")[0] ?? "image";
         const fileNameWithExt = `${fileName}.${fileExt}`;
 
         if (isSvg) {
@@ -97,27 +117,43 @@ export function useFileFetcher({ onError }: FileFetcherOptions = {}) {
           fileContent = await response.arrayBuffer();
         }
 
-        const tempFile = new File([fileContent], fileNameWithExt, { type: fileType });
+        const tempFile = new File([fileContent], fileNameWithExt, {
+          type: fileType,
+        });
 
         await processFile(tempFile);
         return { error: null }; // Success, reset error state
       } catch (err) {
-        if (err instanceof TypeError && err.message.includes("Failed to fetch")) {
-          return { error: "CORS Error: The requested resource does not allow cross-origin requests." };
+        if (
+          err instanceof TypeError &&
+          err.message.includes("Failed to fetch")
+        ) {
+          return {
+            error:
+              "CORS Error: The requested resource does not allow cross-origin requests.",
+          };
         } else if (err instanceof Error) {
           if (err.message.includes("ERR_CERT_AUTHORITY_INVALID")) {
-            return { error: "Invalid certificate. Try using http:// instead of https://." };
-          } else if (err.message.includes("ERR_FAILED") && err.message.includes("301")) {
+            return {
+              error:
+                "Invalid certificate. Try using http:// instead of https://.",
+            };
+          } else if (
+            err.message.includes("ERR_FAILED") &&
+            err.message.includes("301")
+          ) {
             return { error: "The requested image has been moved permanently." };
           } else if (err.message.includes("Failed to fetch")) {
-            return { error: "Network error—the resource may be down or unreachable." };
+            return {
+              error: "Network error—the resource may be down or unreachable.",
+            };
           }
         }
 
         return { error: "Unknown error. Please try again." };
       }
     },
-    { error: null } // Initial state, no form error
+    { error: null }, // Initial state, no form error
   );
 
   useEffect(() => {
@@ -134,6 +170,6 @@ export function useFileFetcher({ onError }: FileFetcherOptions = {}) {
     handleFetchFile,
     pending,
     error: state.error,
-    cancel
+    cancel,
   };
 }

--- a/src/hooks/use-file-fetcher.ts
+++ b/src/hooks/use-file-fetcher.ts
@@ -1,0 +1,139 @@
+import { useActionState, useEffect } from "react";
+import { useProcessFile } from "./use-process-file";
+import { HTTP_ERROR_CODES, validateUrl } from "@/lib/fetch-utils";
+
+export type FileFetcherResult = {
+  /** The processed image content as a data URL (for regular images) or object URL (for SVGs) */
+  imageContent: string;
+  /** The raw file content as a string */
+  rawContent: string;
+  /** Metadata about the uploaded image including dimensions and filename */
+  imageMetadata: {
+    width: number;
+    height: number;
+    name: string;
+  } | null;
+  /** Handler for form state change */
+  handleFetchFile: (payload: FormData) => void;
+  /** Pending state while submitting form */
+  pending: boolean;
+  /** Error message in case of a failed fetch */
+  error: string | null;
+  /** Resets the upload state */
+  cancel: () => void;
+};
+
+type FileFetcherFormState = Pick<FileFetcherResult, "error">
+
+type FileFetcherOptions = {
+  onError?: (error: string) => void;
+}
+
+export function useFileFetcher({ onError }: FileFetcherOptions = {}) {
+  const { imageContent, rawContent, imageMetadata, processFile, cancel } =
+    useProcessFile({ onError });
+
+  const [state, handleFetchFile, pending] = useActionState<FileFetcherFormState, FormData>(
+    async (_, formData: FormData): Promise<FileFetcherFormState> => {
+      const input = formData.get("url") as string;
+      const accept = formData.get("accept") as string | null;
+      
+      if (!input) return { error: "URL is required." };
+      if (!accept) return { error: "Image has invalid or missing MIME type." };
+
+      const validUrl = validateUrl(input);
+      if (!validUrl) return { error: "Invalid URL. Please check and try again." };
+
+      try {
+        const response = await fetch(validUrl);
+
+        if (!response.ok) {
+          switch (response.status) {
+            case 400:
+              return { error: "Invalid request. Please check the URL and try again." };
+            case 403:
+              return { error: "Forbidden—you don't have permission to access this resource." };
+            case 404:
+              return { error: "Image not found. Please check the URL." };
+            case 500:
+              return { error: "Server error. Please try again later." };
+            case 503:
+              return { error: "Service unavailable. Please try again later." };
+            default:
+              let errorMessage = response.status + "";
+              if (HTTP_ERROR_CODES.has(response.status)) errorMessage += ` ${HTTP_ERROR_CODES.get(response.status)}`;
+              return { error: `Failed to retrieve image (Error: ${errorMessage}).` };
+          }
+        }
+
+        const fileType = response.headers.get("Content-Type") ?? "";
+
+        if (!fileType.startsWith("image/")) {
+          return { error: `Requested file is not an image. Please upload a valid image file.` };
+        }
+        
+        let fileExt = "",
+            fileContent: string | ArrayBuffer;
+
+        if (fileType.startsWith("image/")) {
+          fileExt = fileType.split("/").pop() ?? "";
+          if (fileExt === "jpeg") fileExt = "jpg"; // normalize jpg extension
+          if (fileExt === "svg+xml") fileExt = "svg"; // normalize svg extension
+        }
+
+        const isSvg = fileType === "image/svg+xml";
+        const isValidType = accept === "image/*" || fileType.startsWith(accept) || (accept.includes(".svg") && isSvg);
+
+        if (!isValidType) {
+          return { error: `Requested image has invalid type. Valid types are: ${accept}.` };
+        }
+
+        const fileName = new URL(validUrl).pathname.split("/").pop()?.split(".")[0] ?? "image";
+        const fileNameWithExt = `${fileName}.${fileExt}`;
+
+        if (isSvg) {
+          fileContent = await response.text();
+        } else {
+          fileContent = await response.arrayBuffer();
+        }
+
+        const tempFile = new File([fileContent], fileNameWithExt, { type: fileType });
+
+        await processFile(tempFile);
+        return { error: null }; // Success, reset error state
+      } catch (err) {
+        if (err instanceof TypeError && err.message.includes("Failed to fetch")) {
+          return { error: "CORS Error: The requested resource does not allow cross-origin requests." };
+        } else if (err instanceof Error) {
+          if (err.message.includes("ERR_CERT_AUTHORITY_INVALID")) {
+            return { error: "Invalid certificate. Try using http:// instead of https://." };
+          } else if (err.message.includes("ERR_FAILED") && err.message.includes("301")) {
+            return { error: "The requested image has been moved permanently." };
+          } else if (err.message.includes("Failed to fetch")) {
+            return { error: "Network error—the resource may be down or unreachable." };
+          }
+        }
+
+        return { error: "Unknown error. Please try again." };
+      }
+    },
+    { error: null } // Initial state, no form error
+  );
+
+  useEffect(() => {
+    if (state.error) {
+      if (onError) onError(state.error);
+      else alert(state.error);
+    }
+  }, [state.error, onError]);
+
+  return {
+    imageContent,
+    rawContent,
+    imageMetadata,
+    handleFetchFile,
+    pending,
+    error: state.error,
+    cancel
+  };
+}

--- a/src/hooks/use-file-uploader.ts
+++ b/src/hooks/use-file-uploader.ts
@@ -1,7 +1,7 @@
-import { type ChangeEvent } from "react";
-
 import { useClipboardPaste } from "./use-clipboard-paste";
 import { useProcessFile } from "./use-process-file";
+
+import { type ChangeEvent } from "react";
 import { type FileTypeString } from "@/lib/file-utils";
 
 export type FileUploaderResult = {
@@ -61,6 +61,7 @@ export const useFileUploader = ({ accept, onError }: FileUploaderOptions = {}): 
 
   useClipboardPaste({
     acceptedFileTypes,
+    onError,
     onPaste: handleFilePaste,
   }); 
 

--- a/src/hooks/use-file-uploader.ts
+++ b/src/hooks/use-file-uploader.ts
@@ -25,7 +25,7 @@ export type FileUploaderResult = {
 type FileUploaderOptions = {
   accept?: FileTypeString | FileTypeString[];
   onError?: (error: string) => void;
-}
+};
 
 /**
  * A hook for handling file uploads, particularly images and SVGs
@@ -36,17 +36,22 @@ type FileUploaderOptions = {
  * - handleFileUpload: Function to handle file input change events
  * - cancel: Function to reset the upload state
  */
-export const useFileUploader = ({ accept, onError }: FileUploaderOptions = {}): FileUploaderResult => {
+export const useFileUploader = ({
+  accept,
+  onError,
+}: FileUploaderOptions = {}): FileUploaderResult => {
   const { imageContent, rawContent, imageMetadata, processFile, cancel } =
     useProcessFile({ onError });
 
   const acceptedFileTypes: FileTypeString[] = accept
-    ? (Array.isArray(accept) ? accept : [accept])
-    : ["image/*", ".jpg", ".jpeg", ".png", ".webp", ".svg"]; 
+    ? Array.isArray(accept)
+      ? accept
+      : [accept]
+    : ["image/*", ".jpg", ".jpeg", ".png", ".webp", ".svg"];
 
   const handleFileUpload = (file: File) => {
     void processFile(file);
-  }
+  };
 
   const handleFileUploadEvent = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -57,13 +62,13 @@ export const useFileUploader = ({ accept, onError }: FileUploaderOptions = {}): 
 
   const handleFilePaste = (file: File) => {
     void processFile(file);
-  }
+  };
 
   useClipboardPaste({
     acceptedFileTypes,
     onError,
     onPaste: handleFilePaste,
-  }); 
+  });
 
   return {
     imageContent,

--- a/src/hooks/use-file-uploader.ts
+++ b/src/hooks/use-file-uploader.ts
@@ -1,50 +1,8 @@
-import { useCallback } from "react";
-import { type ChangeEvent, useState } from "react";
+import { type ChangeEvent } from "react";
+
 import { useClipboardPaste } from "./use-clipboard-paste";
-
-const parseSvgFile = (content: string, fileName: string) => {
-  const parser = new DOMParser();
-  const svgDoc = parser.parseFromString(content, "image/svg+xml");
-  const svgElement = svgDoc.documentElement;
-  const width = parseInt(svgElement.getAttribute("width") ?? "300");
-  const height = parseInt(svgElement.getAttribute("height") ?? "150");
-
-  // Convert SVG content to a data URL
-  const svgBlob = new Blob([content], { type: "image/svg+xml" });
-  const svgUrl = URL.createObjectURL(svgBlob);
-
-  return {
-    content: svgUrl,
-    metadata: {
-      width,
-      height,
-      name: fileName,
-    },
-  };
-};
-
-const parseImageFile = (
-  content: string,
-  fileName: string,
-): Promise<{
-  content: string;
-  metadata: { width: number; height: number; name: string };
-}> => {
-  return new Promise((resolve) => {
-    const img = new Image();
-    img.onload = () => {
-      resolve({
-        content,
-        metadata: {
-          width: img.width,
-          height: img.height,
-          name: fileName,
-        },
-      });
-    };
-    img.src = content;
-  });
-};
+import { useProcessFile } from "./use-process-file";
+import { type FileTypeString } from "@/lib/file-utils";
 
 export type FileUploaderResult = {
   /** The processed image content as a data URL (for regular images) or object URL (for SVGs) */
@@ -64,6 +22,11 @@ export type FileUploaderResult = {
   cancel: () => void;
 };
 
+type FileUploaderOptions = {
+  accept?: FileTypeString | FileTypeString[];
+  onError?: (error: string) => void;
+}
+
 /**
  * A hook for handling file uploads, particularly images and SVGs
  * @returns {FileUploaderResult} An object containing:
@@ -73,71 +36,39 @@ export type FileUploaderResult = {
  * - handleFileUpload: Function to handle file input change events
  * - cancel: Function to reset the upload state
  */
-export const useFileUploader = (): FileUploaderResult => {
-  const [imageContent, setImageContent] = useState<string>("");
-  const [rawContent, setRawContent] = useState<string>("");
-  const [imageMetadata, setImageMetadata] = useState<{
-    width: number;
-    height: number;
-    name: string;
-  } | null>(null);
+export const useFileUploader = ({ accept, onError }: FileUploaderOptions = {}): FileUploaderResult => {
+  const { imageContent, rawContent, imageMetadata, processFile, cancel } =
+    useProcessFile({ onError });
 
-  const processFile = (file: File) => {
-    const reader = new FileReader();
-    reader.onload = async (e) => {
-      const content = e.target?.result as string;
-      setRawContent(content);
+  const acceptedFileTypes: FileTypeString[] = accept
+    ? (Array.isArray(accept) ? accept : [accept])
+    : ["image/*", ".jpg", ".jpeg", ".png", ".webp", ".svg"]; 
 
-      if (file.type === "image/svg+xml") {
-        const { content: svgContent, metadata } = parseSvgFile(
-          content,
-          file.name,
-        );
-        setImageContent(svgContent);
-        setImageMetadata(metadata);
-      } else {
-        const { content: imgContent, metadata } = await parseImageFile(
-          content,
-          file.name,
-        );
-        setImageContent(imgContent);
-        setImageMetadata(metadata);
-      }
-    };
-
-    if (file.type === "image/svg+xml") {
-      reader.readAsText(file);
-    } else {
-      reader.readAsDataURL(file);
-    }
-  };
+  const handleFileUpload = (file: File) => {
+    void processFile(file);
+  }
 
   const handleFileUploadEvent = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file) {
-      processFile(file);
+      void processFile(file);
     }
   };
 
-  const handleFilePaste = useCallback((file: File) => {
-    processFile(file);
-  }, []);
+  const handleFilePaste = (file: File) => {
+    void processFile(file);
+  }
 
   useClipboardPaste({
+    acceptedFileTypes,
     onPaste: handleFilePaste,
-    acceptedFileTypes: ["image/*", ".jpg", ".jpeg", ".png", ".webp", ".svg"],
-  });
-
-  const cancel = () => {
-    setImageContent("");
-    setImageMetadata(null);
-  };
+  }); 
 
   return {
     imageContent,
     rawContent,
     imageMetadata,
-    handleFileUpload: processFile,
+    handleFileUpload,
     handleFileUploadEvent,
     cancel,
   };

--- a/src/hooks/use-keydown.ts
+++ b/src/hooks/use-keydown.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from "react";
 import { useCallbackRef } from "@/hooks/use-callback-ref";
 
 type Key = "Enter" | "Escape" | "Space" | "ArrowDown" | "ArrowUp"; // Add more keys as needed
-type ModifierKey = "Alt" | "Command" |"Control" | "Meta" | "Shift";
+type ModifierKey = "Alt" | "Command" | "Control" | "Meta" | "Shift";
 type EventCallback = (event: Event) => void;
 type EventTarget = Window | Document | Element;
 
@@ -21,10 +21,14 @@ const modifiersMap = new Map<ModifierKey, string>([
   ["Command", "metaKey"],
   ["Control", "ctrlKey"],
   ["Meta", "metaKey"],
-  ["Shift", "shiftKey"]
+  ["Shift", "shiftKey"],
 ]);
 
-export function useKeyDown(keys: Key | Key[], cb: EventCallback, options: EventOptions = {}) { 
+export function useKeyDown(
+  keys: Key | Key[],
+  cb: EventCallback,
+  options: EventOptions = {},
+) {
   const {
     capture = true,
     condition = true,
@@ -32,10 +36,10 @@ export function useKeyDown(keys: Key | Key[], cb: EventCallback, options: EventO
     modifiers = [],
     preventDefault = false,
     stopPropagation = false,
-    target = globalThis?.document
+    target = globalThis?.document,
   } = options;
 
-  const keyList = useMemo(() => Array.isArray(keys) ? keys : [keys], [keys]);
+  const keyList = useMemo(() => (Array.isArray(keys) ? keys : [keys]), [keys]);
 
   // inspired by Radix UI: https://github.com/radix-ui/primitives/blob/main/packages/react/use-escape-keydown/src/use-escape-keydown.tsx
   // provides a stable reference to the latest version of the callback function without re-registering event listeners
@@ -45,20 +49,27 @@ export function useKeyDown(keys: Key | Key[], cb: EventCallback, options: EventO
     if (condition === false) return;
 
     const handleKeyDown = (event: Event) => {
-      const isKeyMatch = keyList.includes((event as KeyboardEvent).code as Key);  
-      const areModifiersPressed = modifiers.every((m) => (event as KeyboardEvent)[modifiersMap.get(m)! as keyof KeyboardEvent]);
-      const areExcludedModifiersPressed = excludeModifiers.some((m) => (event as KeyboardEvent)[modifiersMap.get(m)! as keyof KeyboardEvent]);
+      const isKeyMatch = keyList.includes((event as KeyboardEvent).code as Key);
+      const areModifiersPressed = modifiers.every(
+        (m) =>
+          (event as KeyboardEvent)[modifiersMap.get(m)! as keyof KeyboardEvent],
+      );
+      const areExcludedModifiersPressed = excludeModifiers.some(
+        (m) =>
+          (event as KeyboardEvent)[modifiersMap.get(m)! as keyof KeyboardEvent],
+      );
 
       if (isKeyMatch && areModifiersPressed && !areExcludedModifiersPressed) {
         if (stopPropagation) event.stopPropagation();
         if (preventDefault) event.preventDefault();
         callbackRef(event as KeyboardEvent);
       }
-    }
+    };
 
     target.addEventListener("keydown", handleKeyDown, { capture });
 
-    return () => target.removeEventListener("keydown", handleKeyDown, { capture });
+    return () =>
+      target.removeEventListener("keydown", handleKeyDown, { capture });
   }, [
     callbackRef,
     capture,

--- a/src/hooks/use-keydown.ts
+++ b/src/hooks/use-keydown.ts
@@ -1,0 +1,73 @@
+import { useEffect, useMemo } from "react";
+import { useCallbackRef } from "@/hooks/use-callback-ref";
+
+type Key = "Enter" | "Escape" | "Space" | "ArrowDown" | "ArrowUp"; // Add more keys as needed
+type ModifierKey = "Alt" | "Command" |"Control" | "Meta" | "Shift";
+type EventCallback = (event: Event) => void;
+type EventTarget = Window | Document | Element;
+
+interface EventOptions {
+  capture?: boolean;
+  condition?: boolean;
+  excludeModifiers?: ModifierKey[];
+  modifiers?: ModifierKey[];
+  preventDefault?: boolean;
+  stopPropagation?: boolean;
+  target?: EventTarget;
+}
+
+const modifiersMap = new Map<ModifierKey, string>([
+  ["Alt", "altKey"],
+  ["Command", "metaKey"],
+  ["Control", "ctrlKey"],
+  ["Meta", "metaKey"],
+  ["Shift", "shiftKey"]
+]);
+
+export function useKeyDown(keys: Key | Key[], cb: EventCallback, options: EventOptions = {}) { 
+  const {
+    capture = true,
+    condition = true,
+    excludeModifiers = [],
+    modifiers = [],
+    preventDefault = false,
+    stopPropagation = false,
+    target = globalThis?.document
+  } = options;
+
+  const keyList = useMemo(() => Array.isArray(keys) ? keys : [keys], [keys]);
+
+  // inspired by Radix UI: https://github.com/radix-ui/primitives/blob/main/packages/react/use-escape-keydown/src/use-escape-keydown.tsx
+  // provides a stable reference to the latest version of the callback function without re-registering event listeners
+  const callbackRef = useCallbackRef(cb);
+
+  useEffect(() => {
+    if (condition === false) return;
+
+    const handleKeyDown = (event: Event) => {
+      const isKeyMatch = keyList.includes((event as KeyboardEvent).code as Key);  
+      const areModifiersPressed = modifiers.every((m) => (event as KeyboardEvent)[modifiersMap.get(m)! as keyof KeyboardEvent]);
+      const areExcludedModifiersPressed = excludeModifiers.some((m) => (event as KeyboardEvent)[modifiersMap.get(m)! as keyof KeyboardEvent]);
+
+      if (isKeyMatch && areModifiersPressed && !areExcludedModifiersPressed) {
+        if (stopPropagation) event.stopPropagation();
+        if (preventDefault) event.preventDefault();
+        callbackRef(event as KeyboardEvent);
+      }
+    }
+
+    target.addEventListener("keydown", handleKeyDown, { capture });
+
+    return () => target.removeEventListener("keydown", handleKeyDown, { capture });
+  }, [
+    callbackRef,
+    capture,
+    condition,
+    excludeModifiers,
+    keyList,
+    modifiers,
+    preventDefault,
+    stopPropagation,
+    target,
+  ]);
+}

--- a/src/hooks/use-media-query.ts
+++ b/src/hooks/use-media-query.ts
@@ -1,0 +1,13 @@
+import { useSyncExternalStore } from "react";
+
+export function useMediaQuery(query: string) {
+  const subscribe = (cb: () => void) => {
+    const mediaQueryList = window.matchMedia(query);
+    mediaQueryList.addEventListener("change", cb);
+    return () => mediaQueryList.removeEventListener("change", cb);
+  };
+
+  const getSnapshot = () => window.matchMedia(query).matches;
+
+  return useSyncExternalStore(subscribe, getSnapshot);
+};

--- a/src/hooks/use-media-query.ts
+++ b/src/hooks/use-media-query.ts
@@ -10,4 +10,4 @@ export function useMediaQuery(query: string) {
   const getSnapshot = () => window.matchMedia(query).matches;
 
   return useSyncExternalStore(subscribe, getSnapshot);
-};
+}

--- a/src/hooks/use-process-file.ts
+++ b/src/hooks/use-process-file.ts
@@ -1,5 +1,9 @@
 import { useState } from "react";
-import { parseSvgFile, parseImageFile, readFileContent } from "@/lib/file-utils";
+import {
+  parseSvgFile,
+  parseImageFile,
+  readFileContent,
+} from "@/lib/file-utils";
 
 export type ProcessFileResult = {
   /** The processed image content as a data URL (for regular images) or object URL (for SVGs) */
@@ -19,7 +23,7 @@ export type ProcessFileResult = {
 
 type ProcessFileOptions = {
   onError?: (error: string) => void;
-}
+};
 
 /**
  * A hook for centralizing file (e.g. svg and raster images) processing logic
@@ -34,7 +38,9 @@ type ProcessFileOptions = {
  * - processFile: Function to process files and set the above three values
  * - cancel: Function to reset the upload state
  */
-export function useProcessFile({ onError }: ProcessFileOptions = {}): ProcessFileResult {
+export function useProcessFile({
+  onError,
+}: ProcessFileOptions = {}): ProcessFileResult {
   const [imageContent, setImageContent] = useState<string>("");
   const [rawContent, setRawContent] = useState<string>("");
   const [imageMetadata, setImageMetadata] = useState<{
@@ -51,17 +57,17 @@ export function useProcessFile({ onError }: ProcessFileOptions = {}): ProcessFil
       if (file.type === "image/svg+xml") {
         const { content: parsedSvgContent, metadata } = parseSvgFile(
           content,
-          file.name
+          file.name,
         );
-        
+
         setImageContent(parsedSvgContent);
         setImageMetadata(metadata);
       } else {
         const { content: parsedImageContent, metadata } = await parseImageFile(
           content,
-          file.name
+          file.name,
         );
-        
+
         setImageContent(parsedImageContent);
         setImageMetadata(metadata);
       }

--- a/src/hooks/use-process-file.ts
+++ b/src/hooks/use-process-file.ts
@@ -1,0 +1,89 @@
+import { useState } from "react";
+import { parseSvgFile, parseImageFile, readFileContent } from "@/lib/file-utils";
+
+export type ProcessFileResult = {
+  /** The processed image content as a data URL (for regular images) or object URL (for SVGs) */
+  imageContent: string;
+  /** The raw file content as a string */
+  rawContent: string;
+  /** Metadata about the uploaded image including dimensions and filename */
+  imageMetadata: {
+    width: number;
+    height: number;
+    name: string;
+  } | null;
+  /** Function that reads file content and sets the above three values */
+  processFile: (file: File) => Promise<void>;
+  cancel: () => void;
+};
+
+type ProcessFileOptions = {
+  onError?: (error: string) => void;
+}
+
+/**
+ * A hook for centralizing file (e.g. svg and raster images) processing logic
+ * in a reusable form factor for use in other, more specialized hooks like
+ * useFileUploader and useFileFetcher.
+ * @param {ProcessFileOptions} [options] - Optional configuration object
+ * @param {function(string): void} [options.onError] - Optional error handler
+ * @returns {ProcessFileResult} An object cont                  aining:
+ * - imageContent: Use this as the src for an img tag
+ * - rawContent: The raw file content as a string (useful for SVG tags)
+ * - imageMetadata: Width, height, and name of the image
+ * - processFile: Function to process files and set the above three values
+ * - cancel: Function to reset the upload state
+ */
+export function useProcessFile({ onError }: ProcessFileOptions = {}): ProcessFileResult {
+  const [imageContent, setImageContent] = useState<string>("");
+  const [rawContent, setRawContent] = useState<string>("");
+  const [imageMetadata, setImageMetadata] = useState<{
+    width: number;
+    height: number;
+    name: string;
+  } | null>(null);
+
+  const processFile = async (file: File): Promise<void> => {
+    try {
+      const content = await readFileContent(file);
+      setRawContent(content);
+
+      if (file.type === "image/svg+xml") {
+        const { content: parsedSvgContent, metadata } = parseSvgFile(
+          content,
+          file.name
+        );
+        
+        setImageContent(parsedSvgContent);
+        setImageMetadata(metadata);
+      } else {
+        const { content: parsedImageContent, metadata } = await parseImageFile(
+          content,
+          file.name
+        );
+        
+        setImageContent(parsedImageContent);
+        setImageMetadata(metadata);
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        if (onError) onError(error.message);
+        else alert(error.message);
+      }
+    }
+  };
+
+  const cancel = () => {
+    setImageContent("");
+    setRawContent("");
+    setImageMetadata(null);
+  };
+
+  return {
+    imageContent,
+    rawContent,
+    imageMetadata,
+    processFile,
+    cancel,
+  };
+}

--- a/src/lib/dom-utils.ts
+++ b/src/lib/dom-utils.ts
@@ -1,0 +1,23 @@
+type InteractiveElementTagName = "ALL" |"INPUT" | "TEXTAREA" | "SELECT" |"BUTTON" | "A";
+
+const defaultTagNames: InteractiveElementTagName[] = ["INPUT", "TEXTAREA", "SELECT", "BUTTON", "A"];
+/**
+ * Checks whether any elements in the document are currently focused.
+ * By default, all types of interactive elements are checked, but the
+ * set of elements to check can be overriden by passing an element's
+ * tag name as a string, or an array of valid tag name strings.
+ */
+export function isInteractiveElementFocused(
+  tagNames: InteractiveElementTagName | InteractiveElementTagName[] = defaultTagNames,
+  classNames?: string | string[]
+): boolean {
+  const tagNamesToTest = tagNames === "ALL" ? defaultTagNames : Array.isArray(tagNames) ? tagNames : [tagNames];
+  const classNamesToTest = Array.isArray(classNames) ? classNames : [classNames];
+  const activeEl = document.activeElement;
+
+  return activeEl instanceof HTMLElement && (
+    activeEl.isContentEditable ||
+    tagNamesToTest.includes(activeEl.tagName as InteractiveElementTagName) ||
+    classNamesToTest.some((className) => className && activeEl.classList.contains(className))
+  );
+}

--- a/src/lib/dom-utils.ts
+++ b/src/lib/dom-utils.ts
@@ -1,6 +1,18 @@
-type InteractiveElementTagName = "ALL" |"INPUT" | "TEXTAREA" | "SELECT" |"BUTTON" | "A";
+type InteractiveElementTagName =
+  | "ALL"
+  | "INPUT"
+  | "TEXTAREA"
+  | "SELECT"
+  | "BUTTON"
+  | "A";
 
-const defaultTagNames: InteractiveElementTagName[] = ["INPUT", "TEXTAREA", "SELECT", "BUTTON", "A"];
+const defaultTagNames: InteractiveElementTagName[] = [
+  "INPUT",
+  "TEXTAREA",
+  "SELECT",
+  "BUTTON",
+  "A",
+];
 /**
  * Checks whether any elements in the document are currently focused.
  * By default, all types of interactive elements are checked, but the
@@ -8,16 +20,28 @@ const defaultTagNames: InteractiveElementTagName[] = ["INPUT", "TEXTAREA", "SELE
  * tag name as a string, or an array of valid tag name strings.
  */
 export function isInteractiveElementFocused(
-  tagNames: InteractiveElementTagName | InteractiveElementTagName[] = defaultTagNames,
-  classNames?: string | string[]
+  tagNames:
+    | InteractiveElementTagName
+    | InteractiveElementTagName[] = defaultTagNames,
+  classNames?: string | string[],
 ): boolean {
-  const tagNamesToTest = tagNames === "ALL" ? defaultTagNames : Array.isArray(tagNames) ? tagNames : [tagNames];
-  const classNamesToTest = Array.isArray(classNames) ? classNames : [classNames];
+  const tagNamesToTest =
+    tagNames === "ALL"
+      ? defaultTagNames
+      : Array.isArray(tagNames)
+        ? tagNames
+        : [tagNames];
+  const classNamesToTest = Array.isArray(classNames)
+    ? classNames
+    : [classNames];
   const activeEl = document.activeElement;
 
-  return activeEl instanceof HTMLElement && (
-    activeEl.isContentEditable ||
-    tagNamesToTest.includes(activeEl.tagName as InteractiveElementTagName) ||
-    classNamesToTest.some((className) => className && activeEl.classList.contains(className))
+  return (
+    activeEl instanceof HTMLElement &&
+    (activeEl.isContentEditable ||
+      tagNamesToTest.includes(activeEl.tagName as InteractiveElementTagName) ||
+      classNamesToTest.some(
+        (className) => className && activeEl.classList.contains(className),
+      ))
   );
 }

--- a/src/lib/fetch-utils.ts
+++ b/src/lib/fetch-utils.ts
@@ -59,7 +59,7 @@ const REGEX_URL = new RegExp(
     "(\\/[-a-z\\d%_.~+=]*)*" + // path string (at least one "/" will be in a valid resource)
     "(\\?[^#]*)?" + // query string (optional)
     "(\\#[-a-z\\d_]*)?$", // URL fragment (optional)
-  "i"
+  "i",
 );
 
 export function validateUrl(input: string) {
@@ -68,9 +68,13 @@ export function validateUrl(input: string) {
   if (!trimmedInput || !REGEX_URL.test(trimmedInput)) return null;
 
   try {
-    const url = new URL(trimmedInput.startsWith('http') ? trimmedInput : `https://${trimmedInput}`);
+    const url = new URL(
+      trimmedInput.startsWith("http")
+        ? trimmedInput
+        : `https://${trimmedInput}`,
+    );
     return url.href;
   } catch {
     return null;
   }
-} 
+}

--- a/src/lib/fetch-utils.ts
+++ b/src/lib/fetch-utils.ts
@@ -1,0 +1,76 @@
+export const HTTP_ERROR_CODES = new Map<number, string>([
+  [400, "Bad Request"],
+  [401, "Unauthorized"],
+  [402, "Payment Required"],
+  [403, "Forbidden"],
+  [404, "Not Found"],
+  [405, "Method Not Allowed"],
+  [406, "Not Acceptable"],
+  [407, "Proxy Authentication Required"],
+  [408, "Request Timeout"],
+  [409, "Conflict"],
+  [410, "Gone"],
+  [411, "Length Required"],
+  [412, "Precondition Failed"],
+  [413, "Payload Too Large"],
+  [414, "URI Too Long"],
+  [415, "Unsupported Media Type"],
+  [416, "Range Not Satisfiable"],
+  [417, "Expectation Failed"],
+  [418, "I'm a teapot"],
+  [421, "Misdirected Request"],
+  [422, "Unprocessable Entity"],
+  [423, "Locked"],
+  [424, "Failed Dependency"],
+  [425, "Too Early"],
+  [426, "Upgrade Required"],
+  [428, "Precondition Required"],
+  [429, "Too Many Requests"],
+  [431, "Request Header Fields Too Large"],
+  [450, "Blocked by Windows Parental Controls"],
+  [451, "Unavailable For Legal Reasons"],
+  [500, "Internal Server Error"],
+  [501, "Not Implemented"],
+  [502, "Bad Gateway"],
+  [503, "Service Unavailable"],
+  [504, "Gateway Timeout"],
+  [505, "HTTP Version Not Supported"],
+  [506, "Variant Also Negotiates"],
+  [507, "Insufficient Storage"],
+  [508, "Loop Detected"],
+  [509, "Bandwidth Limit Exceeded"],
+  [510, "Not Extended"],
+  [511, "Network Authentication Required"],
+  [520, "Cloudflare Web Server Returned an Unknown Error"],
+  [521, "Cloudflare Web Server Is Down"],
+  [522, "Cloudflare Connection Timed Out"],
+  [523, "Cloudflare Origin Is Unreachable"],
+  [524, "Cloudflare Timeout Occurred"],
+  [525, "Cloudflare SSL Handshake Failed"],
+  [598, "Network Read Timeout Error"],
+  [599, "Network Connect Timeout Error"],
+]);
+
+const REGEX_URL = new RegExp(
+  "^(https?:\\/\\/)?" + // protocol (optional)
+    "((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|" + // domain name
+    "((\\d{1,3}\\.){3}\\d{1,3}))" + // or, IPv4 address
+    "(\\:\\d+)?" + // port (optional)
+    "(\\/[-a-z\\d%_.~+=]*)*" + // path string (at least one "/" will be in a valid resource)
+    "(\\?[^#]*)?" + // query string (optional)
+    "(\\#[-a-z\\d_]*)?$", // URL fragment (optional)
+  "i"
+);
+
+export function validateUrl(input: string) {
+  const trimmedInput = input.trim();
+
+  if (!trimmedInput || !REGEX_URL.test(trimmedInput)) return null;
+
+  try {
+    const url = new URL(trimmedInput.startsWith('http') ? trimmedInput : `https://${trimmedInput}`);
+    return url.href;
+  } catch {
+    return null;
+  }
+} 

--- a/src/lib/file-utils.ts
+++ b/src/lib/file-utils.ts
@@ -3,13 +3,25 @@ import type { ChangeEvent } from "react";
 import type { FileUploaderResult } from "@/hooks/use-file-uploader";
 import type { FileFetcherResult } from "@/hooks/use-file-fetcher";
 
-export type ImageMetadata = FileUploaderResult["imageMetadata"] | FileFetcherResult["imageMetadata"];
+export type ImageMetadata =
+  | FileUploaderResult["imageMetadata"]
+  | FileFetcherResult["imageMetadata"];
 
 export type FileType = "Image (any type)" | "JPG" | "PNG" | "WEBP" | "SVG";
-export type FileTypeString = "image/*" | "image/jpeg" | ".jpg" | ".jpeg" | "image/png" | ".png" | "image/webp" | ".webp" | "image/svg+xml" | ".svg";
+export type FileTypeString =
+  | "image/*"
+  | "image/jpeg"
+  | ".jpg"
+  | ".jpeg"
+  | "image/png"
+  | ".png"
+  | "image/webp"
+  | ".webp"
+  | "image/svg+xml"
+  | ".svg";
 
 // Mapping of file extensions and MIME types to human-readable file types
-export const allFileTypes: { type: FileTypeString, group: FileType }[] = [
+export const allFileTypes: { type: FileTypeString; group: FileType }[] = [
   { type: "image/*", group: "Image (any type)" },
   { type: ".jpeg", group: "JPG" },
   { type: ".jpg", group: "JPG" },
@@ -25,7 +37,7 @@ export const allFileTypes: { type: FileTypeString, group: FileType }[] = [
 // Create a no-op function that satisfies the linter
 const noop = () => {
   /* intentionally empty */
-}
+};
 
 export function createFileChangeEvent(
   file: File,
@@ -60,7 +72,7 @@ export function createFileChangeEvent(
 
 export function parseImageFile(
   content: string,
-  fileName: string
+  fileName: string,
 ): Promise<{
   content: string;
   metadata: { width: number; height: number; name: string };
@@ -81,7 +93,7 @@ export function parseImageFile(
   });
 }
 
-export function parseSvgFile(content: string, fileName: string) { 
+export function parseSvgFile(content: string, fileName: string) {
   const parser = new DOMParser();
   const svgDoc = parser.parseFromString(content, "image/svg+xml");
   const svgElement = svgDoc.documentElement;
@@ -90,7 +102,7 @@ export function parseSvgFile(content: string, fileName: string) {
   let height = parseInt(svgElement.getAttribute("height") ?? "");
 
   // If width and height are not expliclitly defined, try to extract them from the viewBox attribute
-  if ((!width || !height) && viewBox) { 
+  if ((!width || !height) && viewBox) {
     const viewBoxValues = viewBox.split(" ").map(parseFloat);
     if (viewBoxValues.length === 4) {
       width = viewBoxValues[2]!;
@@ -98,7 +110,8 @@ export function parseSvgFile(content: string, fileName: string) {
     }
   }
 
-  if (isNaN(width) || isNaN(height)) throw new TypeError("Unable to parse SVG. File may be corrupted.");
+  if (isNaN(width) || isNaN(height))
+    throw new TypeError("Unable to parse SVG. File may be corrupted.");
 
   // Convert SVG content to a data URL
   const svgBlob = new Blob([content], { type: "image/svg+xml" });
@@ -114,7 +127,7 @@ export function parseSvgFile(content: string, fileName: string) {
   };
 }
 
-export function readFileContent(file: File): Promise<string> { 
+export function readFileContent(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
 
@@ -140,9 +153,11 @@ export function readFileContent(file: File): Promise<string> {
  */
 export function generateFileTypesString(accepted: FileTypeString[]) {
   return [
-    ...new Set(accepted
-      .map((acceptedType) => allFileTypes
-        .find(({ type }) => type === acceptedType)!.group
-      ))
+    ...new Set(
+      accepted.map(
+        (acceptedType) =>
+          allFileTypes.find(({ type }) => type === acceptedType)!.group,
+      ),
+    ),
   ].join(", ");
 }

--- a/src/lib/file-utils.ts
+++ b/src/lib/file-utils.ts
@@ -1,9 +1,31 @@
 import type { ChangeEvent } from "react";
 
+import type { FileUploaderResult } from "@/hooks/use-file-uploader";
+import type { FileFetcherResult } from "@/hooks/use-file-fetcher";
+
+export type ImageMetadata = FileUploaderResult["imageMetadata"] | FileFetcherResult["imageMetadata"];
+
+export type FileType = "Image (any type)" | "JPG" | "PNG" | "WEBP" | "SVG";
+export type FileTypeString = "image/*" | "image/jpeg" | ".jpg" | ".jpeg" | "image/png" | ".png" | "image/webp" | ".webp" | "image/svg+xml" | ".svg";
+
+// Mapping of file extensions and MIME types to human-readable file types
+export const allFileTypes: { type: FileTypeString, group: FileType }[] = [
+  { type: "image/*", group: "Image (any type)" },
+  { type: ".jpeg", group: "JPG" },
+  { type: ".jpg", group: "JPG" },
+  { type: "image/jpeg", group: "JPG" },
+  { type: ".png", group: "PNG" },
+  { type: "image/png", group: "PNG" },
+  { type: ".webp", group: "WEBP" },
+  { type: "image/webp", group: "WEBP" },
+  { type: ".svg", group: "SVG" },
+  { type: "image/svg+xml", group: "SVG" },
+] as const;
+
 // Create a no-op function that satisfies the linter
 const noop = () => {
   /* intentionally empty */
-};
+}
 
 export function createFileChangeEvent(
   file: File,
@@ -34,4 +56,93 @@ export function createFileChangeEvent(
     isTrusted: true,
     persist: noop,
   } as ChangeEvent<HTMLInputElement>;
+}
+
+export function parseImageFile(
+  content: string,
+  fileName: string
+): Promise<{
+  content: string;
+  metadata: { width: number; height: number; name: string };
+}> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      resolve({
+        content,
+        metadata: {
+          width: img.width,
+          height: img.height,
+          name: fileName,
+        },
+      });
+    };
+    img.src = content;
+  });
+}
+
+export function parseSvgFile(content: string, fileName: string) { 
+  const parser = new DOMParser();
+  const svgDoc = parser.parseFromString(content, "image/svg+xml");
+  const svgElement = svgDoc.documentElement;
+  const viewBox = svgElement.getAttribute("viewBox");
+  let width = parseInt(svgElement.getAttribute("width") ?? "");
+  let height = parseInt(svgElement.getAttribute("height") ?? "");
+
+  // If width and height are not expliclitly defined, try to extract them from the viewBox attribute
+  if ((!width || !height) && viewBox) { 
+    const viewBoxValues = viewBox.split(" ").map(parseFloat);
+    if (viewBoxValues.length === 4) {
+      width = viewBoxValues[2]!;
+      height = viewBoxValues[3]!;
+    }
+  }
+
+  if (isNaN(width) || isNaN(height)) throw new TypeError("Unable to parse SVG. File may be corrupted.");
+
+  // Convert SVG content to a data URL
+  const svgBlob = new Blob([content], { type: "image/svg+xml" });
+  const svgUrl = URL.createObjectURL(svgBlob);
+
+  return {
+    content: svgUrl,
+    metadata: {
+      width,
+      height,
+      name: fileName,
+    },
+  };
+}
+
+export function readFileContent(file: File): Promise<string> { 
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = (e) => {
+      if (!e.target?.result) {
+        reject(new Error("Unable to read file"));
+      } else {
+        resolve(e.target.result as string);
+      }
+    };
+
+    if (file.type === "image/svg+xml") {
+      reader.readAsText(file);
+    } else {
+      reader.readAsDataURL(file);
+    }
+  });
+}
+
+/**
+ * Given a list of accepted file extensions and/or MIME types, generates
+ * a human-readable string of accepted file types for display purposes.
+ */
+export function generateFileTypesString(accepted: FileTypeString[]) {
+  return [
+    ...new Set(accepted
+      .map((acceptedType) => allFileTypes
+        .find(({ type }) => type === acceptedType)!.group
+      ))
+  ].join(", ");
 }

--- a/src/lib/math-utils.ts
+++ b/src/lib/math-utils.ts
@@ -1,0 +1,18 @@
+/**
+ *  Rounding function for neatly displaying pixel values
+ * 
+ *  Examples:
+ *  formatNumber(124)                 // 124
+ *  formatNumber(201.5)               // 201.5
+ *  formatNumber(88.56)               // 88.56
+ *  formatNumber(299.636)             // 299.64
+ *  formatNumber(67.699)              // 67.7
+ *  formatNumber(454.99999999999994)  // 455
+ *  formatNumber(12.340)              // 12.34
+ *  formatNumber(5.6000)              // 5.6
+ */
+
+export function formatNumber(value: number): number {
+  const rounded = Math.round(value * 100) / 100;
+  return parseFloat(rounded.toString());
+}

--- a/src/lib/math-utils.ts
+++ b/src/lib/math-utils.ts
@@ -1,6 +1,6 @@
 /**
  *  Rounding function for neatly displaying pixel values to a maximum of 2 decimal places.
- * 
+ *
  *  Examples:
  *  formatNumber(124)                 // 124
  *  formatNumber(201.5)               // 201.5

--- a/src/lib/math-utils.ts
+++ b/src/lib/math-utils.ts
@@ -1,5 +1,5 @@
 /**
- *  Rounding function for neatly displaying pixel values
+ *  Rounding function for neatly displaying pixel values to a maximum of 2 decimal places.
  * 
  *  Examples:
  *  formatNumber(124)                 // 124

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,10 @@
 import type { Config } from "tailwindcss";
 
+const widths = {
+  sm: "40rem",
+  container: "25rem",
+} as const;
+
 const config: Config = {
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
@@ -12,8 +17,18 @@ const config: Config = {
         background: "var(--background)",
         foreground: "var(--foreground)",
       },
+      width: {
+        ...widths,
+      },
+      maxWidth: {
+        ...widths,
+      },
+      screens: {
+        ...widths,
+      },
     },
   },
   plugins: [],
 };
+
 export default config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,8 @@
 import type { Config } from "tailwindcss";
 
 const widths = {
+  "2xs": "20rem",
+  xs: "29rem",
   sm: "40rem",
   container: "25rem",
 } as const;


### PR DESCRIPTION
Hi Theo, long time sub/viewer, but first time contributor to one of your projects.

I love this simple little app, but time and again I found myself repeatedly running into a limitation in the original featureset.  A very common use case for me is to need to edit images using the tool that exist online, or that I find online via a web search.  As it stands, this requires me to download a file every time and then re-upload it in order to use the tool.

This PR and feature branch, provides this missing functionality, in the form of an alternative way of inputting images in each of the three tools—*fetch file from URL*.  Basically, when using any of the tools, a user can either click upload/drag and drop/paste a file to upload, or—with these changes—they can copy and paste any URL that resolves to an image and the app will fetch that file, process it, and use that image instead.

# TL;DR, Major Changes
- [x] Added ability to fetch files from URL
- [x] Standardized & generalized processing logic between existing file upload and new file fetching functionality
- [x] Improved error-handling, especially in terms of user experience
- [x] App-wide accessibility improvements and 100% keyboard navigability
- [x] Improved usability at smaller, mobile screen sizes
- [x] Calculate and display scale of preview images for users, when uploaded images are larger than container and sized to fit 
- [x] Preview SVGs on light background as well as default dark background before converting to PNG
- [x] Add transparent background option to square image tool
- [x] Add "cover" image-fit mode to existing "contain" mode for square image tool, with a new toggle/option selector, as an alternative way to derive a square image from an existing image 
- [x] Improvements on input and validation for custom SVG scale and custom border radius input
- [x] Improved, standardized styling across the app, while staying true to its minimalist origins
- [x] General organizational improvements and consolidation of duplicate code into components

~~BTW, I'm currently looking for work.  I'm what is more and more being called a "Design Engineer"—I have 15+ years experience both as a senior/lead product designer and as a developer (full stack, but most of my work tends to be more front-end-y).  React+TypeScript is my center of gravity and has been since 2018.  See: [www.avanavana.com](www.avanavana.com)~~

nm the above, I landed a dream job shortly after submitting this PR! 🎉

# Videos

🎥 **Demoing fetch file from URL and SVG scale factor improvements**
https://github.com/user-attachments/assets/e49b3890-6f14-4ed5-97aa-3f835197b7d0

🎥 **Demoing some of the new features, dynamic preview scale, keyboard navigation, etc**
https://github.com/user-attachments/assets/deb28194-ca78-41c3-8576-468a4a66e12b

🎥 **Demoing corner rounder proportional border radius improvement**
https://github.com/user-attachments/assets/7115ffec-a247-403c-9a81-397b0f770dd2

🎥 **Demoing behavior of "too-wide" and "too-tall" images with screen-size change**
https://github.com/user-attachments/assets/3b1fec9b-8f6e-47ed-90e2-cea994246b62

# Summary

In implementing the fetch file from URL feature, I aimed for maximum parity and mutual intelligibility between the existing `useFileUploader()` hook by implementing it with a new custom hook, `useFileFetcher()`, which uses React's new-ish `useActionState()` hook on the back-end, as well as by abstracting/generalizing the file processing logic that was previously located entirely within `useFileUploader()` as its own `useProcessFile()` hook, which now serves both hooks/methods of retrieving files.

Along with implementing this feature I also implemented better error handling, especially from the point of view of users.  Instead of console errors and `alert()`, there are now real error messages whose state lives at the top level of each tool and whose set method is passed into the `useFileUploader()`, `useClipboardPaste()`, and new `useFileFetcher()` hooks, allowing each method of file retrieval to produce and render its own distinct errors in a simple, centralized way.

I also implemented accessible keyboard navigation for all interactive elements, using a powerful new, custom `useKeydown()` hook so the entire app can be controlled by means of keyboard control, and I implemented WAI-ARIA best practices.

For the option selector components like `OptionSelector`, `SvgScaleSelector`, and `BorderRadiusSelector`, at small screen sizes, those with many options (especially `SvgScaleSelector`) were overflowing in the x-direction.  I implemented a simple `useMediaQuery()` hook to conditionally render these option selector components with a new custom `Select` component at small screen sizes.  Initially I tried implementing it with a native `<select>` element, but the conditional mounting led to a problem where, due to browser restrictions, the newly-mounted native element was unable to be operated with a single click/touch event—the first click/touch event would focus the element but the browser would then prevent its options from being shown—until after a second click/touch event.  This was unacceptable from a UX perspective, so I decided to implement it as a custom `Select` component.  This component is fully accessible and keyboard-navigable, using all the same events as the native element.

Beyond this, I did some work standardizing and improving styling across the app, while keeping it true to the original look and feel, and  I consolidated and standardized various pieces of UI shared across the three tools.

A full list of the updates is provided below, along with the testing I performed.

# Additions & Updates (Full List)

## Home
- [x] Center paragraph text
- [x] Make links tab-navigable and accessible and give them hover+focus styles
- [x] Standardize default, hover, and focus styles of all header and footer links
- [x] Add icons to 3 primary tool links to help distinguish and highlight them
- [x] Standardize capitalization of all tool links and style them more like other links (e.g. hover/focus styles should be either color change or underline, but not a mix of both throughout app—I went for color change)

## All Tools
- [x] Standardize capitalization of page titles on all tools, to keep them consistent with capitalization on home page
- [x] Add page titles to tool screens by passing down title from metadata object in each tool's `page.tsx` file
- [x] Standardize default, hover, and focus styles of all header and footer links
- [x] Encapsulate footer into shared, reusable component
- [x] Standardize capitalization of `FileDropzone` text
- [x] Add same upload icon to `FileDropZone` component
- [x] Standardize text color between `FileDropzone` and `UploadBox`
- [x] Initial tool screen
  - [x] Add fetch file from URL form
  - [x] Add fetch file from URL custom hook
  - [x] Standardize file upload and fetch from URL hook return objects
  - [x] Generalize file upload and fetch from URL hooks to both use the same new `useProcessFile()` custom hook, which performs standardized file processing logic behind the scenes and allows for standard implementations of multiple methods of file input
  - [x] Add tab navigation between file upload, url input, & url submit
  - [x] Add escape key exit to home screen
  - [x] Add enter & space key triggers for file upload
  - [x] Standardize error reporting for all user input methods
    - [x] Create `ErrorMessage` component
    - [x] Standardize error throwing and catching to use new Error Message component and handle errors globally with tool-level error state as a single source of truth, so that errors resulting from any input method are each displayed using the same top-level error state and update correctly
    - [x] File upload
      - [x] Upload via upload form
        - [x] Invalid/non-image file displays error
        - [x] Invalid image type displays error
        - [x] Invalid/corrupted file displays error
      - [x] Upload via paste from clipboard
        - [x] Invalid/non-image file displays error
        - [x] Invalid image type displays error
        - [x] Invalid/corrupted file displays error
      - [x] Upload via drag and drop
        - [x] Invalid/non-image file displays error
        - [x] Invalid image type displays error
        - [x] Invalid/corrupted file displays error
    - [x] Fetch from URL
      - [x] Invalid/non-image file displays error
      - [x] Invalid file type displays error
      - [x] Invalid/corrupt file displays error
      - [x] Invalid url displays error
      - [x] Missing url displays error
      - [x] Unresolvable url displays error
      - [x] Protected/forbidden url displays error
      - [x] CORS protection displays error
      - [x] Remote server error displays error
      - [x] Malformed request displays error
      - [x] Invalid HTTPS/TLS certificate displays error
      - [x] Permanently moved resource displays error
  - [x] Standardize styles for all input elements, including hover & focus states
  - [x] Standardize styles for all button elements, including hover & focus states
  - [x] Make file drop zone slightly wider to allow for a little more room for new fetch from URL form below
  - [x] Replace ugly file upload icon with nicer file upload icon from lucide icons
  - [x] Add "allows paste from clipboard" message to all initial tool screens
- [x] Preview screen
  - [x] Add dynamic preview scale % above image preview
  - [x] Add escape key to trigger cancel
  - [x] Calculate width & height for SVGs without explicit width and height from SVG `viewBox` attribute, instead of arbitrary 300x150 size, which caused issues with centering user-provided content in the square image tool
  - [x] Display all images under maximum width/height dimensions (determined by container) at actual size
  - [x] Scale all images with at least one dimension larger than maximum container width/height down according to their largest dimension
  - [x] Add "0.5x" value to scale options
  - [x] Validate and format input for custom scale
  - [x] render as select dropdown below xs (29rem—i.e. 25rem + 2rem padding) breakpoint
    - [x] Create custom `Select` component, since browser restrictions prevent the use of native `<select>` (when the native select mounts after screen resize, the browser prevents initial click events, requiring users to click twice with the menu flashing open and closed very quickly and awkwardly—unacceptable)
      - [x] Maintain all standard input styles, including hover and focus styles
      - [x] Handle all native-equivalent keydown events for accessibility
        - [x] ArrowUp/ArrowDown/Enter/Space to open select menu options
        - [x] ArrowUp/ArrowDown to navigate menu options, with infinite cycling at first and last options
        - [x] Enter/Space to select a menu option
        - [x] Escape to close menu options and/or blur select element
      - [x] Handle all native-equivalent mouse events
      - [x] Integrate component with `OptionSelector`/`SvgScaleSelector`/`BorderRadiusSelector` state
      - [x] Implement all necessary WAI-ARIA attributes for accessibility
      - [x] Replace native `<select>` element with new custom `Select` component, conditionally rendering it in `OptionSelector`/`SvgScaleSelector`/`BorderRadiusSelector` when the screen is below the "xs" breakpoint, and in a 50/50 flex-row arrangement with the "custom" input field when it is present
  - [x] Add native-style keyboard controls (spacebar + down arrow to open, arrow keys to change selected option, option/alt or cmd + arrow keys to jump to top/bottom of options, enter or spacebar to confirm selection) to `<select>` version of scale selector
  - [x] Add "Allows pasting images from clipboard" message to all initial tool screens
  - [x] Add clipboard paste icon to "Allows pasting images from clipboard" message
  - [x] Drag and drop
    - [x] Render actual drag and drop error messages below UI instead of alert dialogs and console errors

## SVG to PNG tool
- [x] Initial tool screen
  - [x] Paste from clipboard
    - [x] Only accept `*.svg` files from paste from clipboard
- [x] Preview screen
  - [x] Add preview scale % above image preview
  - [x] Center original/scaled size text

## Square image tool
- [x] Preview screen
  - [x] Add preview scale % above image preview
  - [x] Center original/square size text
  - [x] Add "transparent" option for export
  - [x] Transparent option shows very faint "checkboard" pattern in extra portions of the new square image that help distinguish it from the default black background and give proper feedback to users after they choose "transparent" as an option
  - [x] Fix bug where SVGs without explicit width and height can't be center positioned in square (fixed by using viewbox attribute to size SVG)
  - [x] Encapsulate "Save Image" element into a separate component defined in square-tool.tsx
  - [x] Add new `OptionSelector` component to allow users to toggle between "contain" (existing behavior) and "cover" image-fit/object-fit modes/methods of "squaring" a source image. 

## Rounded corner tool
- [x] Preview screen
  - [x] Add preview scale % above image preview
  - [x] Center actual size text
  - [x] Add "transparent" option for export
  - [x] Transparent option shows very faint "checkboard" pattern behind rounded corners that help distinguish it from the default black background and give proper feedback to users after they choose "transparent" as an option
  - [x] Add "1px" value to radius options
  - [x] Validate and format input for custom radius

## General/components
- [x] Group and sort all imports in a standardized way in all files as 1. react+installed packages (react first, then next, then other installed packages in ascending lexicographical order), 2. components (asc. lex. order), 3. hooks/lib/utils (in that order, and then asc. lex. order within each group), and finally, 4. imported types (asc. lex. order), with a single newline space between import groups
- [x] Standardize button styles across app (no more "success" and "destructive" bg colors—nothing about "cancel" is irreversible or causes loss of data, and in other contexts, primary CTA uses the "blue" color.  Cleaner and simpler design if all buttons just use the same style, cancel can use a secondary "ghosted" style. 
- [x] Standardize input styles across app. Unify heights, padding, typography, colors, and hover/focus states.
- [x] Distinguish external from internal links with up-and-to-the-right arrow icon
- [x] Encapsulate footer into shared, reusable component
  - [x] Add subtle GitHub logo icon to GitHub link
- [x] `UploadBox`
  - [x] Slightly widen upload box to give more room for fetch from URL form below
  - [x] Replace ugly icon with better-proportioned icon
  - [x] Make text color consistent and better-balanced
- [x] `FileDropzone`
  - [x] Add same updated upload icon from `UploadBox`
  - [x] Review usage of `useCallback()` throughout app to avoid premature or negligible optimization, i.e. unnecessary usage of useCallback that may add unnecessary overhead (`useCallback()` only makes sense in cases where 1. heavy computation is necessary, 2. referential equality is necessary, and 3. in general, where it actually improves performance in a way that can be measured (i.e. measure performance before & after before employing it).  `useCallback()` is generally unnecessary when it is used with both no dependencies and the function it wraps is not being passed to any props in child components.  In other words, if it is used to wrap handlers in a function that are not passed down and only used in that component, with no dependencies, and no heavy computation, it is unnecessary and just adding to overhead.

# Testing

## main screen
- [x] tab navigation between 3 main tool links
- [x] links should not be un-focusable/blur-able with Escape key (as with all native link tab focus)
- [x] all links have consistent font styles, including hover & focus states (other than color, which is used to indicate external 
- [x] main content should be vertically and horizontally centered in window

## all tools
- [x] initial tool screen
  - [x] tab navigation between file upload, url input, & url submit
  - [x] escape exits to main page
  - [x] enter opens file upload
  - [x] space opens file upload
  - [x] if file upload button is not focused, enter and space do not open file upload
  - [x] escape does not blur file upload when focused (ensure native behavior)
  - [x] focus on file upload does not block escape key exit to main page
  - [x] enter attempts to submit url form when either url input or submit button are focused
  - [x] enter does not submit url form when neither url input nor submit button are focused
  - [x] attempt to submit empty url form results in focused input
  - [x] enter does not submit url form when url input is empty
  - [x] empty url form submission does not trigger native input required popover
  - [x] empty url form submission results in "URL is required" error message, without any network requests being sent
  - [x] escape blurs url input when focused (ensure native behavior)
  - [x] escape does not blur url submit button when focused (ensure native behavior)
  - [x] focus on url submit button does not block escape key exit to main page
  - [x] all input elements have consistent styles, including hover & focus states
  - [x] all button elements have consistent styles, including hover & focus states
  - [x] file upload + url upload UI is fixed width above sm (30rem) breakpoint
  - [x] file upload + url upload UI is 100% fluid width (minus padding) below "xs" (29rem—i.e. 25rem + 2rem padding) breakpoint
  - [x] smooth transition between fixed and fluid layouts across "xs" breakpoint
  - [x] main content should be vertically and horizontally centered in window 
  - [x] use file upload button to upload
    - [x] invalid file type displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
    - [x] invalid/corrupt file displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
  - [x] drag and drop to upload
    - [x] invalid file type displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
    - [x] invalid/corrupt file displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
  - [x] paste from clipboard to upload
    - [x] non-image file type displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
    - [x] invalid file type displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
    - [x] invalid/corrupt file displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
  - [x] fetch from url to upload
    - [x] non-image file displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
    - [x] invalid file type displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
    - [x] invalid/corrupt file displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
    - [x] invalid url displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
    - [x] missing url displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
    - [x] unresolvable url displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
    - [x] protected/forbidden url displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
    - [x] CORS protection displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
    - [x] remote server error displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
    - [x] malformed request displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
    - [x] invalid HTTPS/TLS certificate displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
    - [x] permanently moved resource displays error
      - [x] SVG to PNG
      - [x] Square Image
      - [x] Rounded Corners
  - [x] existing error message is replaced with any new error messages (only one error message displayed at once)
  - [x] errors dismissed after valid upload or url fetch, or navigation to main page and back again to initial tool screen
- [x] preview screen
  - [x] paste new image over existing image in preview
  - [x] tab navigation between all option inputs, cancel, and save buttons
  - [x] all input elements have consistent styles, including hover & focus states
  - [x] all button elements have consistent styles, including hover & focus states
  - [x] cancel button exits to initial tool screen
  - [x] escape cancels to initial tool screen
  - [x] escape blurs focused inputs, buttons (including option selector component buttons), & links before canceling to initial tool screen
  - [x] preview scale calculated correctly
  - [x] preview scale changes with screen + image preview resize
  - [x] preview image scales smoothly through different breakpoints
  - [x] if image is shown at actual size (i.e. image dimensions are both less than the maximum container size), preview scale should not be shown
  - [x] if any dimension of an image is greater than the maximum container size, the preview scale should always be shown, with the scale percentage displayed equal to the maximum container size divided by the image's largest dimension
  - [x] main content should be vertically and horizontally centered in screen

# svg-to-png-tool
- [x] initial tool screen
  - [x] upload
    - [x] smaller than max size in both dimensions
    - [x] wider than max size
    - [x] taller than max size
    - [x] larger than max size in both dimensions
    - [x] paste from clipboard to upload should only accept *.svg files
  - [x] fetch from URL
    - [x] smaller than max size in both dimensions
    - [x] wider than max size
    - [x] taller than max size
    - [x] larger than max size in both dimensions
    - [x] enter submits url form
- [x] preview screen
  - [x] choose preview background
    - [x] preview on light bg
    - [x] preview on dark bg
  - [x] choose export scale
    - [x] fixed scales
      - [x] scaled (fixed) size is calculated correctly
      - [x] export at fixed scale
    - [x] custom scale
      - [x] show placeholder when empty
      - [x] set value to 1 if empty or 0
      - [x] set value to 64 if user manually enters a value above 64
      - [x] manually enter any real number 0 < x <= 64
      - [x] leading and trailing whitespace is removed
      - [x] decimal values always have only one leading zero
      - [x] trailing zeroes are removed
      - [x] user must not be able to enter non-numeric characters
      - [x] step values up and down by 1 with mouse clicks on buttons
      - [x] step values up and down by 10 with mouse clicks on buttons + shift key
      - [x] step values up and down by 0.1 with mouse clicks on buttons + alt/option key
      - [x] tab to step up/down buttons
      - [x] step values up and down by 1 with arrow keys
      - [x] step values up and down by 10 with arrow keys + shift key
      - [x] step values up and down by 0.1 with arrow keys + alt/option keys
      - [x] scaled (custom) size is calculated correctly
      - [x] scaled (custom) size is only ever shown with a maximum of 2 decimal places in all locations other than the actual user's input in the custom scale input field.
      - [x] custom scales all result in images with whole number dimensions
      - [x] user can successfully export at any custom scale
    - [x] render as custom `Select` component below "xs" (29rem—i.e. 25rem + 2rem inline padding) breakpoinirgvt gfvv
    - [x] open and operate `Select` with native keyboard controls (spacebar + down arrow to open, arrow keys to change selected option, option/alt or cmd + arrow keys to jump to top/bottom of options, enter or spacebar to confirm selection)
    - [x] selected item should be preserved between display mode changes (between the normal and `Select` display modes across the 30rem breakpoint 

# square-tool
- [x] initial tool screen
  - [x] upload
    - [x] smaller than max size in both dimensions
      - [x] svg with transparency
      - [x] svg with full bleed
      - [x] png with transparency
      - [x] png with full bleed
      - [x] jpg
      - [x] webp
    - [x] wider than max size
      - [x] svg with transparency
      - [x] svg with full bleed
      - [x] png with transparency
      - [x] png with full bleed
      - [x] jpg
      - [x] webp
    - [x] taller than max size
      - [x] svg with transparency
      - [x] svg with full bleed
      - [x] png with transparency
      - [x] png with full bleed
      - [x] jpg
      - [x] webp
    - [x] larger than max size in both dimensions
      - [x] svg with transparency
      - [x] svg with full bleed
      - [x] png with transparency
      - [x] png with full bleed
      - [x] jpg
      - [x ] webp
  - [x] fetch from URL
    - [x] smaller than max size in both dimensions
      - [x] svg with transparency
      - [x] svg with full bleed
      - [x] png with transparency
      - [x] png with full bleed
      - [x] jpg
      - [x] webp
    - [x] wider than max size
      - [x] svg with transparency
      - [x] svg with full bleed
      - [x] png with transparency
      - [x] png with full bleed
      - [x] jpg
      - [x] webp
    - [x] taller than max size
      - [x] svg with transparency
      - [x] svg with full bleed
      - [x] png with transparency
      - [x] png with full bleed
      - [x] jpg
      - [x] webp
    - [x] larger than max size in both dimensions
      - [x] svg with transparency
      - [x] svg with full bleed
      - [x] png with transparency
      - [x] png with full bleed
      - [x] jpg
      - [x] webp
- [x] preview
  - [x] choose background
    - [x] white bg
      - [x] preview updates correctly
      - [x] export saves correctly
    - [x] black bg
      - [x] preview updates correctly
      - [x] export saves correctly
    - [x] transparent bg
      - [x] preview updates correctly
      - [x] export saves correctly
  - [x] choose image fit mode
    - [x] contain
      - [x] preview updates correctly
      - [x] sizes update correctly
      - [x] export saves correctly 
    - [x] cover
      - [x] preview updates correctly
      - [x] sizes update correctly
      - [x] export saves correctly

# rounded-tool
- [x] initial tool screen
  - [x] upload
    - [x] smaller than max size in both dimensions
      - [x] svg with transparency
      - [x] svg with full bleed
      - [x] png with transparency
      - [x] png with full bleed
      - [x] jpg
      - [x] webp
    - [x] wider than max size
      - [x] svg with transparency
      - [x] svg with full bleed
      - [x] png with transparency
      - [x] png with full bleed
      - [x] jpg
      - [x] webp
    - [x] taller than max size
      - [x] svg with transparency
      - [x] svg with full bleed
      - [x] png with transparency
      - [x] png with full bleed
      - [x] jpg
      - [x] webp
    - [x] larger than max size in both dimensions
      - [x] svg with transparency
      - [x] svg with full bleed
      - [x] png with transparency
      - [x] png with full bleed
      - [x] jpg
      - [x] webp
    - [x] enter opens file upload
    - [x] space opens file upload
    - [x] if file upload button is not focused, enter and space do not open file upload
  - [x] fetch from URL
    - [x] smaller than max size in both dimensions
      - [x] svg with transparency
      - [x] svg with full bleed
      - [x] png with transparency
      - [x] png with full bleed
      - [x] jpg
      - [x] webp
    - [x] wider than max size
      - [x] svg with transparency
      - [x] svg with full bleed
      - [x] png with transparency
      - [x] png with full bleed
      - [x] jpg
      - [x] webp
    - [x] taller than max size
      - [x] svg with transparency
      - [x] svg with full bleed
      - [x] png with transparency
      - [x] png with full bleed
      - [x] jpg
      - [x] webp
    - [x] larger than max size in both dimensions
      - [x] svg with transparency
      - [x] svg with full bleed
      - [x] png with transparency
      - [x] png with full bleed
      - [x] jpg
      - [x] webp
    - [x] enter submits url form
    - [x] escape cancels to initial tool screen
- [x] preview screen
  - [x] choose background
    - [x] white bg
      - [x] preview updates correctly
      - [x] export saves correctly
    - [x] black bg
      - [x] preview updates correctly
      - [x] export saves correctly
    - [x] transparent bg
      - [x] preview updates correctly
      - [x] export saves correctly
  - [x] choose border radius
    - [x] fixed radii
      - [x] border radius is calculated correctly
      - [x] border radius is scaled correctly in preview according to image preview scale 
      - [x] exports correctly
    - [x] custom radius
      - [x] show placeholder when empty = -1
      - [x] set value to 1 if empty or 0 = 1
      - [x] set value to 999 if user manually enters a value gte 1000,
      - [x] manually enter any real number 0 < x < 1000 (e.g. a user can manually enter numbers arbitrarily close to 0 and 1000)
      - [x] leading and trailing whitespace is removed
      - [x] decimal values always have only one leading zero
      - [x] trailing zeroes are removed
      - [x] user must not be able to enter non-numeric characters
      - [x] step values up and down by 1 with mouse clicks on buttons
      - [x] step values up and down by 10 with mouse clicks on buttons + shift key
      - [x] step values up and down by 0.1 with mouse clicks on buttons + alt/option key
      - [x] tab to step up/down buttons
      - [x] step values up and down by 1 with arrow keys
      - [x] step values up and down by 10 with arrow keys + shift key
      - [x] step values up and down by 0.1 with arrow keys + alt/option keys
      - [x] custom radii are applied to the preview image at the correct scale depending on whether the preview image itself is scaled to fit its container (i.e. whether its dimensions exceed the container or not
    - [x] render as custom `Select` component below "xs" (29rem—i.e. 25rem + 2rem inline padding)
    - [x] open and operate `Select` with native keyboard controls (spacebar + down arrow to open, arrow keys to change selected option, option/alt or cmd + arrow keys to jump to top/bottom of options, enter or spacebar to confirm selection)
    - [x] selected item should be preserved between display mode changes (between the normal and `Select` display modes across the 30rem breakpoint 