### PR TITLE
Fix aspect ratios of certain SVGs, also better data handling in general

### DIFF
--- a/src/hooks/use-async-memo.ts
+++ b/src/hooks/use-async-memo.ts
@@ -1,0 +1,27 @@
+import { type DependencyList, useCallback, useEffect, useState } from "react";
+
+export const useAsyncMemo = <T, L>(
+  factory: () => Promise<T>,
+  deps: DependencyList,
+  loadingState: L,
+  errorState?: (error: unknown) => L,
+): T | L => {
+  const [result, setResult] = useState<T | L>(loadingState);
+  const defaultErrorState = useCallback(() => loadingState, [loadingState]);
+  if (!errorState) errorState = defaultErrorState;
+
+  useEffect(() => {
+    setResult(loadingState);
+
+    factory().then(
+      (value) => {
+        setResult(value);
+      },
+      (error) => {
+        setResult(errorState(error));
+      },
+    );
+  }, [factory, loadingState, errorState, deps]);
+
+  return result;
+};


### PR DESCRIPTION
By "certain SVGs", I mean ones without `width` or `height` attributes and instead just doing `viewBox` or something else. Previously, my SVGs (square) would always show up as 300x150 and would have extra transparent padding on the sides. This fixes that, so that the images would at least have the right aspect ratio, even if the dimensions aren't correct. The way I did this is to use `HTMLImageElement.naturalWidth` and `naturalHeight` - letting the browser do all the complicated work with the standards. (this means that the SVG-to-PNG tool can technically resize other image types if the accepted file types are changed)

"Better data handling" is using `blob:` URLs instead of `data:` URLs everywhere possible, so we're not passing around massive strings with file contents, instead we're just using references to `Blob`s, and those `Blob`s hold the data outside of JavaScript. Additionally, there were some `blob:` URLs already being used (with SVG content) but not being freed with `URL.revokeObjectURL`, so I added some `useEffect` calls to clean those up.

No visual changes, this is purely logic. Except for the results being the correct aspect ratio.

Please make sure you do the following before filing your PR:
- [x] Provide a video or screenshots of any visual changes made
- [x] Run `pnpm run check` and make sure everything passes